### PR TITLE
fix: 修复Trivy扫描结果为空时解析失败 #48

### DIFF
--- a/src/backend/common/common-analysis/src/main/kotlin/com/tencent/bkrepo/common/analysis/pojo/scanner/trivy/TrivyScanResult.kt
+++ b/src/backend/common/common-analysis/src/main/kotlin/com/tencent/bkrepo/common/analysis/pojo/scanner/trivy/TrivyScanResult.kt
@@ -35,7 +35,7 @@ import io.swagger.annotations.ApiModelProperty
 data class TrivyScanResults(
     @ApiModelProperty("扫描结果")
     @JsonAlias("Results")
-    val results: List<TrivyScanResult>
+    val results: List<TrivyScanResult> = emptyList()
 )
 
 @ApiModel("制品漏洞信息")


### PR DESCRIPTION
close #48 