### PR TITLE
perf: 添加applyMavenExclusions #17

### DIFF
--- a/src/backend/build.gradle.kts
+++ b/src/backend/build.gradle.kts
@@ -47,6 +47,8 @@ allprojects {
     apply(plugin = "jacoco")
 
     dependencyManagement {
+        applyMavenExclusions(false)
+
         imports {
             mavenBom("org.springframework.cloud:spring-cloud-sleuth-otel-dependencies:${Versions.SleuthOtel}")
         }


### PR DESCRIPTION
 #17
# 耗时原因
**Gradle**和**Maven**的依赖排除逻辑不一样，**pom**文件中定义的**exclusion**，**Maven**会根据最短路径原则，选择到的最短路径中如果排除了依赖才排除，而**Gradle**则是全部依赖都排除才会排除，只要有一个依赖间接引用了被排除的依赖，都会引入

```
maven 的行为
the first one will include C in the result,
but the second one won't (because the path with the exclude is shorter) 
and the third one won't (because the path with the exclude was the first one found).

Project -> A -(exclude C)-> B -> C
        \-> B -> C

Project -> A -(exclude C)-> B -> C
        \-> D -> E -> B -> C

Project -> A -(exclude C)-> B -> C
        \-> D -> B -> C

而gradle要A,B,D,E都排除了C，最终才会排除C
```
**Gradle**的`io.spring.dependency-management`插件在构建时为了模拟**Maven**的依赖排除逻辑，会产生大量`detached configurations`，并且耗时很久

调整后执行` ./gradlew clean build -x test` 时间由**3m 28s**降低到**2m 52s**

[Occurrence of dependency-management-plugin leads to bad performance](https://github.com/spring-gradle-plugins/dependency-management-plugin/issues/222)

# 依赖变更情况
![image](https://user-images.githubusercontent.com/16629885/204252087-ae09315d-4262-4eb2-8540-2968f592985d.png)
