### PR TITLE
feat: 修复helm服务启动后converter bean创建报错 #73

### DIFF
--- a/src/backend/helm/biz-helm/src/main/kotlin/com/tencent/bkrepo/helm/config/DateConverterConfig.kt
+++ b/src/backend/helm/biz-helm/src/main/kotlin/com/tencent/bkrepo/helm/config/DateConverterConfig.kt
@@ -45,15 +45,19 @@ class DateConverterConfig {
      */
     @Bean
     fun localDateTimeConverter(): Converter<String, LocalDateTime> {
-        return Converter { source ->
-            LocalDateTime.parse(source, DateTimeFormatter.ofPattern(DEFAULT_DATE_TIME_FORMAT))
+        return object: Converter<String, LocalDateTime> {
+            override fun convert(source: String): LocalDateTime {
+                return LocalDateTime.parse(source, DateTimeFormatter.ofPattern(DEFAULT_DATE_TIME_FORMAT))
+            }
         }
     }
 
     @Bean
     fun localDateConverter(): Converter<String, LocalDate> {
-        return Converter { source ->
-            LocalDate.parse(source, DateTimeFormatter.ofPattern(DEFAULT_DATE_FORMAT))
+        return object: Converter<String, LocalDate> {
+            override fun convert(source: String): LocalDate {
+                return LocalDate.parse(source, DateTimeFormatter.ofPattern(DEFAULT_DATE_FORMAT))
+            }
         }
     }
 


### PR DESCRIPTION
由于取不到lambda表达式的类型参数信息导致创建converter bean失败
#73 