### PR TITLE
修复制品分报告页面非管理员无权限访问 

### DIFF
--- a/src/backend/analyst/api-analyst/src/main/kotlin/com/tencent/bkrepo/analyst/pojo/response/SubtaskResultOverview.kt
+++ b/src/backend/analyst/api-analyst/src/main/kotlin/com/tencent/bkrepo/analyst/pojo/response/SubtaskResultOverview.kt
@@ -41,6 +41,8 @@ data class SubtaskResultOverview(
     val scanner: String,
     @ApiModelProperty("扫描器类型")
     val scannerType: String,
+    @ApiModelProperty("扫描类型")
+    val scanTypes: List<String> = emptyList(),
 
     @ApiModelProperty("制品名")
     val name: String,

--- a/src/backend/analyst/biz-analyst/src/main/kotlin/com/tencent/bkrepo/analyst/service/impl/ScanTaskServiceImpl.kt
+++ b/src/backend/analyst/biz-analyst/src/main/kotlin/com/tencent/bkrepo/analyst/service/impl/ScanTaskServiceImpl.kt
@@ -213,7 +213,8 @@ class ScanTaskServiceImpl(
             logger.info("Failed to checkSubtaskPermission: ", e)
             permissionCheckHandler.checkProjectPermission(subtask.projectId, PermissionAction.MANAGE)
         }
-        return Converter.convert(subtask)
+        val scanTypes = subtask.planId?.let { scanPlanDao.findById(it) }?.scanTypes ?: emptyList()
+        return Converter.convert(subtask, scanTypes)
     }
 
     private fun subtasks(request: SubtaskInfoRequest, subtaskDao: AbsSubScanTaskDao<*>): Page<SubtaskInfo> {

--- a/src/backend/analyst/biz-analyst/src/main/kotlin/com/tencent/bkrepo/analyst/utils/Converter.kt
+++ b/src/backend/analyst/biz-analyst/src/main/kotlin/com/tencent/bkrepo/analyst/utils/Converter.kt
@@ -118,7 +118,7 @@ object Converter {
         }
     }
 
-    fun convert(subScanTask: SubScanTaskDefinition): SubtaskResultOverview {
+    fun convert(subScanTask: SubScanTaskDefinition, scanTypes: List<String>): SubtaskResultOverview {
         return with(subScanTask) {
             val critical = getCveCount(Level.CRITICAL.levelName, subScanTask)
             val high = getCveCount(Level.HIGH.levelName, subScanTask)
@@ -130,6 +130,7 @@ object Converter {
                 subTaskId = subScanTask.id!!,
                 scanner = scanner,
                 scannerType = scannerType,
+                scanTypes = scanTypes,
                 name = artifactName,
                 packageKey = packageKey,
                 version = version,

--- a/src/frontend/devops-repository/src/views/repoScan/artiReport/index.vue
+++ b/src/frontend/devops-repository/src/views/repoScan/artiReport/index.vue
@@ -59,18 +59,14 @@
             }
         },
         created () {
-            this.getScanConfig({ projectId: this.projectId, id: this.planId })
-                .then(res => {
-                    this.scanTypes = res.scanTypes
-                    this.panels = res.scanTypes.map(scanType => this.allPanels[scanType])
-                })
-
             this.artiReportOverview({
                 projectId: this.projectId,
                 recordId: this.recordId,
                 taskId: this.taskId,
                 viewType: this.viewType
             }).then(res => {
+                this.scanTypes = res.scanTypes
+                this.panels = res.scanTypes.map(scanType => this.allPanels[scanType])
                 this.subtaskOverview = {
                     ...res,
                     highestLeakLevel: leakLevelEnum[res.highestLeakLevel],


### PR DESCRIPTION
CLOSE #229 

添加扫描类型字段到预览数据接口，移除报告页对扫描方案详情接口的调用