### PR TITLE
feat: 修复maven服务启动失败 #224

### DIFF
--- a/src/backend/maven/biz-maven/src/main/kotlin/com/tencent/bkrepo/maven/service/impl/center/CommitEdgeCenterMavenMetadataServiceImpl.kt
+++ b/src/backend/maven/biz-maven/src/main/kotlin/com/tencent/bkrepo/maven/service/impl/center/CommitEdgeCenterMavenMetadataServiceImpl.kt
@@ -1,0 +1,40 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-CI 蓝鲸持续集成平台 available.
+ *
+ * Copyright (C) 2023 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * BK-CI 蓝鲸持续集成平台 is licensed under the MIT license.
+ *
+ * A copy of the MIT License is included in this file.
+ *
+ *
+ * Terms of the MIT License:
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+ * LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+ * NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.tencent.bkrepo.maven.service.impl.center
+
+import com.tencent.bkrepo.common.service.cluster.CommitEdgeCenterCondition
+import com.tencent.bkrepo.maven.dao.MavenMetadataDao
+import com.tencent.bkrepo.maven.service.MavenMetadataService
+import org.springframework.context.annotation.Conditional
+import org.springframework.stereotype.Service
+
+@Service
+@Conditional(CommitEdgeCenterCondition::class)
+class CommitEdgeCenterMavenMetadataServiceImpl(
+    mavenMetadataDao: MavenMetadataDao
+) : MavenMetadataService(mavenMetadataDao)


### PR DESCRIPTION
由于DefaultCondition注解只会在非commit-edge架构下生效，所以center节点未创建对应的MavenMetadataService Bean导致服务启动失败