### PR TITLE
feat: 限制非GENERIC仓库不允许跨集群操作 #224

### DIFF
--- a/src/backend/repository/biz-repository/src/main/kotlin/com/tencent/bkrepo/repository/service/node/impl/center/CommitEdgeCenterNodeServiceImpl.kt
+++ b/src/backend/repository/biz-repository/src/main/kotlin/com/tencent/bkrepo/repository/service/node/impl/center/CommitEdgeCenterNodeServiceImpl.kt
@@ -28,6 +28,7 @@
 package com.tencent.bkrepo.repository.service.node.impl.center
 
 import com.tencent.bkrepo.common.api.exception.ErrorCodeException
+import com.tencent.bkrepo.common.api.message.CommonMessageCode
 import com.tencent.bkrepo.common.artifact.message.ArtifactMessageCode
 import com.tencent.bkrepo.common.artifact.path.PathUtils
 import com.tencent.bkrepo.common.security.util.SecurityUtils
@@ -51,6 +52,7 @@ import com.tencent.bkrepo.repository.service.node.impl.NodeRestoreSupport
 import com.tencent.bkrepo.repository.service.node.impl.NodeServiceImpl
 import com.tencent.bkrepo.repository.service.repo.QuotaService
 import com.tencent.bkrepo.repository.service.repo.StorageCredentialService
+import com.tencent.bkrepo.repository.util.ClusterUtils
 import com.tencent.bkrepo.repository.util.NodeQueryHelper
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Conditional
@@ -85,9 +87,9 @@ class CommitEdgeCenterNodeServiceImpl(
     override fun checkRepo(projectId: String, repoName: String): TRepository {
         val repo = repositoryDao.findByNameAndType(projectId, repoName)
             ?: throw ErrorCodeException(ArtifactMessageCode.REPOSITORY_NOT_FOUND, repoName)
-        val region = SecurityUtils.getClusterName()
-        if (!region.isNullOrBlank() && !repo.clusterNames.orEmpty().contains(region)) {
-            throw ErrorCodeException(ArtifactMessageCode.REPOSITORY_NOT_FOUND, repoName)
+
+        if (!ClusterUtils.containsSrcCluster(repo.clusterNames)) {
+            throw ErrorCodeException(CommonMessageCode.OPERATION_CROSS_CLUSTER_NOT_ALLOWED)
         }
         return repo
     }

--- a/src/backend/repository/biz-repository/src/main/kotlin/com/tencent/bkrepo/repository/service/packages/impl/PackageBaseService.kt
+++ b/src/backend/repository/biz-repository/src/main/kotlin/com/tencent/bkrepo/repository/service/packages/impl/PackageBaseService.kt
@@ -31,9 +31,11 @@ import com.tencent.bkrepo.common.api.exception.ErrorCodeException
 import com.tencent.bkrepo.common.artifact.message.ArtifactMessageCode
 import com.tencent.bkrepo.common.artifact.util.version.SemVersion
 import com.tencent.bkrepo.repository.dao.PackageDao
+import com.tencent.bkrepo.repository.dao.RepositoryDao
 import com.tencent.bkrepo.repository.model.ClusterResource
 import com.tencent.bkrepo.repository.model.TPackage
 import com.tencent.bkrepo.repository.model.TPackageVersion
+import com.tencent.bkrepo.repository.model.TRepository
 import com.tencent.bkrepo.repository.pojo.packages.request.PackagePopulateRequest
 import com.tencent.bkrepo.repository.pojo.packages.request.PackageVersionCreateRequest
 import com.tencent.bkrepo.repository.pojo.packages.request.PopulatedPackageVersion
@@ -43,7 +45,10 @@ import org.slf4j.LoggerFactory
 import org.springframework.dao.DuplicateKeyException
 import java.time.LocalDateTime
 
-abstract class PackageBaseService(protected val packageDao: PackageDao) : PackageService {
+abstract class PackageBaseService(
+    protected val repositoryDao: RepositoryDao,
+    protected val packageDao: PackageDao
+) : PackageService {
 
     protected open fun checkPackageVersionOverwrite(
         overwrite: Boolean,
@@ -165,6 +170,14 @@ abstract class PackageBaseService(protected val packageDao: PackageDao) : Packag
             metadata = MetadataUtils.compatibleConvertAndCheck(metadata, packageMetadata),
             extension = extension.orEmpty()
         )
+    }
+
+    /**
+     * 校验仓库是否存在
+     */
+    open fun checkRepo(projectId: String, repoName: String): TRepository {
+        return repositoryDao.findByNameAndType(projectId, repoName)
+            ?: throw ErrorCodeException(ArtifactMessageCode.REPOSITORY_NOT_FOUND, repoName)
     }
 
     /**

--- a/src/backend/repository/biz-repository/src/main/kotlin/com/tencent/bkrepo/repository/service/packages/impl/PackageServiceImpl.kt
+++ b/src/backend/repository/biz-repository/src/main/kotlin/com/tencent/bkrepo/repository/service/packages/impl/PackageServiceImpl.kt
@@ -49,6 +49,7 @@ import com.tencent.bkrepo.common.service.util.HttpContextHolder
 import com.tencent.bkrepo.common.service.util.SpringContextUtils.Companion.publishEvent
 import com.tencent.bkrepo.repository.dao.PackageDao
 import com.tencent.bkrepo.repository.dao.PackageVersionDao
+import com.tencent.bkrepo.repository.dao.RepositoryDao
 import com.tencent.bkrepo.repository.model.TPackage
 import com.tencent.bkrepo.repository.model.TPackageVersion
 import com.tencent.bkrepo.repository.pojo.packages.PackageListOption
@@ -75,10 +76,11 @@ import java.time.LocalDateTime
 @Service
 @Conditional(DefaultCondition::class)
 class PackageServiceImpl(
+    repositoryDao: RepositoryDao,
     packageDao: PackageDao,
     protected val packageVersionDao: PackageVersionDao,
     private val packageSearchInterpreter: PackageSearchInterpreter
-) : PackageBaseService(packageDao) {
+) : PackageBaseService(repositoryDao, packageDao) {
 
     override fun findPackageByKey(projectId: String, repoName: String, packageKey: String): PackageSummary? {
         val tPackage = packageDao.findByKey(projectId, repoName, packageKey)

--- a/src/backend/repository/biz-repository/src/main/kotlin/com/tencent/bkrepo/repository/service/packages/impl/edge/EdgePackageServiceImpl.kt
+++ b/src/backend/repository/biz-repository/src/main/kotlin/com/tencent/bkrepo/repository/service/packages/impl/edge/EdgePackageServiceImpl.kt
@@ -33,6 +33,7 @@ import com.tencent.bkrepo.common.service.feign.FeignClientFactory
 import com.tencent.bkrepo.repository.api.PackageClient
 import com.tencent.bkrepo.repository.dao.PackageDao
 import com.tencent.bkrepo.repository.dao.PackageVersionDao
+import com.tencent.bkrepo.repository.dao.RepositoryDao
 import com.tencent.bkrepo.repository.pojo.packages.request.PackageUpdateRequest
 import com.tencent.bkrepo.repository.pojo.packages.request.PackageVersionCreateRequest
 import com.tencent.bkrepo.repository.pojo.packages.request.PackageVersionUpdateRequest
@@ -45,11 +46,13 @@ import org.springframework.stereotype.Service
 @Service
 @Conditional(CommitEdgeEdgeCondition::class)
 class EdgePackageServiceImpl(
+    repositoryDao: RepositoryDao,
     packageDao: PackageDao,
     packageVersionDao: PackageVersionDao,
     packageSearchInterpreter: PackageSearchInterpreter,
     clusterProperties: ClusterProperties
 ) : PackageServiceImpl(
+    repositoryDao,
     packageDao,
     packageVersionDao,
     packageSearchInterpreter


### PR DESCRIPTION
由于依赖源类型的仓库存在index、metadata等类型的多个package或packageVersion共享的文件，同一个仓库的package属于不同集群时可能会出现跨集群操作错误，因此限制依赖源仓库只允许属于一个集群