### PR TITLE
bug: generic上传失败后没有任务提示，但是接口显示(net::ERR_CONNECTION_CLOSED) #320

### DIFF
--- a/src/frontend/devops-repository/src/views/repoGeneric/genericUploadDialog.vue
+++ b/src/frontend/devops-repository/src/views/repoGeneric/genericUploadDialog.vue
@@ -103,10 +103,17 @@
                 }).catch(e => {
                     this.uploadDialog.uploadStatus = 'primary'
                     this.uploadDialog.uploadProgress = 0
-                    e && this.$bkMessage({
-                        theme: 'error',
-                        message: e.message || e
-                    })
+                    if (!e) {
+                        this.$bkMessage({
+                            theme: 'error',
+                            message: 'Error: File size too large'
+                        })
+                    } else {
+                        this.$bkMessage({
+                            theme: 'error',
+                            message: e.message || e
+                        })
+                    }
                 }).finally(() => {
                     this.uploadDialog.loading = false
                 })


### PR DESCRIPTION
此异常是由于文件过大，请求被网关截断，异常无任何错误信息（复现条件为上传大于10g的文件）