### PR TITLE
fix: 制品分析的方案详情页的许可证总数取值不正确,当许可证总数为0时会显示漏洞总数的数据#374

### DIFF
--- a/src/frontend/devops-repository/src/views/repoScan/scanReport/overview.vue
+++ b/src/frontend/devops-repository/src/views/repoScan/scanReport/overview.vue
@@ -130,7 +130,7 @@
                 )).then(res => {
                     res.forEach(planCount =>
                         Object.keys(this.overview).forEach(key => {
-                            this.overview[key] = planCount[key] || this.overview[key]
+                            this.overview[key] = planCount[key] ?? this.overview[key]
                         })
                     )
                 })


### PR DESCRIPTION
fix: 制品分析的方案详情页的许可证总数取值不正确,当许可证总数为0时会显示漏洞总数的数据