### PR TITLE
fix: 软件源模式下依赖源仓库的制品详情页的元数据展示为空且控制台有报错 #425

### DIFF
--- a/src/frontend/devops-repository/src/views/repoCommon/metadataTag.vue
+++ b/src/frontend/devops-repository/src/views/repoCommon/metadataTag.vue
@@ -48,7 +48,8 @@
                 type: [Array, Object]
             },
             metadataLabelList: {
-                type: Array
+                type: Array,
+                default: () => []
             }
         },
         computed: {
@@ -69,7 +70,7 @@
             // 根据元数据的 key 和 value，获取 value 的配色
             getColorMap () {
                 return function (key, value) {
-                    const label = this.metadataLabelList.find(item => item.labelKey === key)
+                    const label = this.metadataLabelList?.find(item => item.labelKey === key)
                     return label?.labelColorMap[value] || '#333333'
                 }
             }


### PR DESCRIPTION
fix: 软件源模式下依赖源仓库的制品详情页的元数据展示为空且控制台有报错 #425