### PR TITLE
fix: 制品详情页点击扫描结果标签进入扫描详情页后点击重新扫描按钮，控制台报错且页面右侧显示空白页 #487

### DIFF
--- a/src/frontend/devops-repository/src/views/repoScan/artiReport/index.vue
+++ b/src/frontend/devops-repository/src/views/repoScan/artiReport/index.vue
@@ -110,7 +110,7 @@
                     name: this.subtaskOverview.packageKey ? 'commonPackage' : 'repoGeneric',
                     params: {
                         projectId: this.projectId,
-                        repoType: this.subtaskOverview.repoType
+                        repoType: this.subtaskOverview.repoType?.toLowerCase()
                     },
                     query: (
                         this.subtaskOverview.packageKey


### PR DESCRIPTION
fix: 制品详情页点击扫描结果标签进入扫描详情页后点击重新扫描按钮，控制台报错且页面右侧显示空白页 #487