### PR TITLE
fix: generic仓库详情页在目录树中搜索文件夹名后列表全屏显示但清除搜索值后目录树不显示 #621

### DIFF
--- a/src/frontend/devops-repository/src/views/repoGeneric/index.vue
+++ b/src/frontend/devops-repository/src/views/repoGeneric/index.vue
@@ -869,6 +869,7 @@
         .repo-generic-table {
             flex: 1;
             height: 100%;
+            width:0;
             background-color: white;
             .multi-operation {
                 height: 50px;


### PR DESCRIPTION
fix: generic仓库详情页在目录树中搜索文件夹名后列表全屏显示但清除搜索值后目录树不显示 #621