### PR TITLE
fix: 制品详情页中版本名称过长时，删除弹窗的版本名称超过弹窗的限制 #767

### DIFF
--- a/src/frontend/devops-repository/src/components/ConfirmDialog/index.vue
+++ b/src/frontend/devops-repository/src/components/ConfirmDialog/index.vue
@@ -10,7 +10,7 @@
                 <i :class="`bk-icon icon-${getIcon()}`"></i>
                 <span class="ml10">{{ message }}</span>
             </div>
-            <span class="confirm-tip">{{ subMessage }}</span>
+            <span class="confirm-tip" :title="subMessage">{{ subMessage }}</span>
         </div>
         <template #footer>
             <bk-button @click="cancel">{{$t('cancel')}}</bk-button>
@@ -100,6 +100,10 @@
         margin-left: 35px;
         display: inline-block;
         margin-top: 12px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        width: 90%;
     }
 }
 </style>

--- a/src/frontend/devops-repository/src/views/repoCommon/commonPackageDetail.vue
+++ b/src/frontend/devops-repository/src/views/repoCommon/commonPackageDetail.vue
@@ -291,7 +291,8 @@
             deleteVersionHandler ({ name: version } = this.currentVersion) {
                 this.$confirm({
                     theme: 'danger',
-                    message: this.$t('deleteVersionTitle', { version }),
+                    message: this.$t('deleteVersionTitle', { name: '' }),
+                    subMessage: version,
                     confirmFn: () => {
                         return this.deleteVersion({
                             projectId: this.projectId,


### PR DESCRIPTION
fix: 制品详情页中版本名称过长时，删除弹窗的版本名称超过弹窗的限制 #767