### PR TITLE
bugfix: Generic制品搜索没有找到制品时浏览器控制台报错 #858

### DIFF
--- a/src/backend/repository/biz-repository/src/main/kotlin/com/tencent/bkrepo/repository/service/node/impl/NodeSearchServiceImpl.kt
+++ b/src/backend/repository/biz-repository/src/main/kotlin/com/tencent/bkrepo/repository/service/node/impl/NodeSearchServiceImpl.kt
@@ -84,7 +84,15 @@ class NodeSearchServiceImpl(
             repos.filter { it !in (exRepo.split(',')) }
         } else repos
 
-        if (genericRepos.isEmpty()) return listOf()
+        if (genericRepos.isEmpty()) {
+            return listOf(
+                ProjectPackageOverview(
+                    projectId = projectId,
+                    repos = mutableSetOf(),
+                    sum = 0L
+                )
+            )
+        }
         return transTree(projectId, genericRepos)
     }
 


### PR DESCRIPTION
Generic制品搜索结果没有制品时返回空数组，与有数据时结构不一致，导致浏览器控制台报错
issue #858