### PR TITLE
fix: 单体服务pypi simple重定向到错误的url #1272

### DIFF
--- a/src/backend/pypi/biz-pypi/src/main/kotlin/com/tencent/bkrepo/pypi/artifact/repository/PypiLocalRepository.kt
+++ b/src/backend/pypi/biz-pypi/src/main/kotlin/com/tencent/bkrepo/pypi/artifact/repository/PypiLocalRepository.kt
@@ -104,7 +104,6 @@ import java.time.format.DateTimeFormatter
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
-import javax.servlet.http.HttpServletRequest
 
 @Component
 class PypiLocalRepository(
@@ -336,9 +335,8 @@ class PypiLocalRepository(
     /**
      * 本地调试删除 pypi.domain 配置
      */
-    fun getRedirectUrl(request: HttpServletRequest): String {
+    fun getRedirectUrl(path: String): String {
         val domain = pypiProperties.domain
-        val path = request.servletPath
         return UrlFormatter.format(domain, path).ensureSuffix(StringPool.SLASH)
     }
 
@@ -346,11 +344,10 @@ class PypiLocalRepository(
      *
      */
     fun getSimpleHtml(artifactInfo: ArtifactInfo): Any? {
-        val request = HttpContextHolder.getRequest()
-        if (!request.requestURI.endsWith("/")) {
+        val path = ArtifactContextHolder.getUrlPath(this.javaClass.name)!!
+        if (!path.endsWith("/")) {
             val response = HttpContextHolder.getResponse()
-            response.sendRedirect(getRedirectUrl(request))
-            response.writer.flush()
+            response.sendRedirect(getRedirectUrl(path))
             return null
         }
         with(artifactInfo) {


### PR DESCRIPTION
issue:
1. #1272

描述：
访问pypi simple查询接口时，如果url最后不带斜杠，将触发重定向。单体服务模式下重定向url不正确。