### PR TITLE
fix: oci仓库访问不包含路径的代理源地址时可能无法通过鉴权 #1342

### DIFF
--- a/src/backend/oci/biz-oci/src/main/kotlin/com/tencent/bkrepo/oci/artifact/repository/OciRegistryRemoteRepository.kt
+++ b/src/backend/oci/biz-oci/src/main/kotlin/com/tencent/bkrepo/oci/artifact/repository/OciRegistryRemoteRepository.kt
@@ -399,11 +399,10 @@ class OciRegistryRemoteRepository(
         }
     }
 
-
     private fun getScope(remoteUrl: String, imageName: String): String {
         val baseUrl = URL(remoteUrl)
-        val target = baseUrl.path.removePrefix(StringPool.SLASH)
-            .removeSuffix(StringPool.SLASH) + StringPool.SLASH + imageName
+        val path = baseUrl.path.removePrefix(StringPool.SLASH).removeSuffix(StringPool.SLASH)
+        val target = if (path.isBlank()) imageName else path + StringPool.SLASH + imageName
         return "repository:$target:pull"
     }
 


### PR DESCRIPTION
issue:
1. #1342 

描述：
假设oci仓库设置了不包含路径的代理源地址（url形式为`{scheme}://{domain}`而不是`{scheme}://{domain}/{path}`），当访问该代理源的资源返回401时，oci仓库将根据响应头的内容请求用于获取token的url，此时该url的查询参数scope多了斜杠`repository:/{repository}:{accessSet}`，导致获取的token在用于后续请求资源时可能无法通过鉴权。