### PR TITLE
fix: 修复SVN-PROXY响应的Content-Length设置错误导致SVN拉取失败 #1572

### DIFF
--- a/src/backend/svn/biz-svn/src/main/kotlin/com/tencent/bkrepo/svn/interceptor/ChangeAncestorProxyHandler.kt
+++ b/src/backend/svn/biz-svn/src/main/kotlin/com/tencent/bkrepo/svn/interceptor/ChangeAncestorProxyHandler.kt
@@ -141,9 +141,9 @@ class ChangeAncestorProxyHandler(
                     oldBody,
                     buildSearchList(oldPrefix),
                     buildReplacementList(newPrefix)
-                )
-                proxyResponse.setHeader(HttpHeaders.CONTENT_LENGTH, newBody.length.toString())
-                proxyResponse.writer.write(newBody)
+                ).toByteArray()
+                proxyResponse.setContentLength(newBody.size)
+                proxyResponse.outputStream.write(newBody)
             }
         } else {
             response.body?.byteStream()?.use {


### PR DESCRIPTION
1. #1572 