### PR TITLE
fix: 页面下载版本号带+的制品失败 #1576

### DIFF
--- a/src/frontend/devops-repository/src/views/repoCommon/commonPackageDetail.vue
+++ b/src/frontend/devops-repository/src/views/repoCommon/commonPackageDetail.vue
@@ -308,7 +308,7 @@
             },
             downloadPackageHandler (row = this.currentVersion) {
                 if (this.repoType === 'docker') return
-                const url = `/repository/api/version/download/${this.projectId}/${this.repoName}?packageKey=${this.packageKey}&version=${row.name}&download=true`
+                const url = `/repository/api/version/download/${this.projectId}/${this.repoName}?packageKey=${this.packageKey}&version=${encodeURIComponent(row.name)}&download=true`
                 this.$ajax.head(url).then(() => {
                     window.open(
                         '/web' + url,


### PR DESCRIPTION
issue:
1. #1576

描述:
1. 根据[SemVer2](https://semver.org/)规范，版本号可能包含"+"。
2. 根据[RFC 3986](https://www.rfc-editor.org/rfc/rfc3986#section-2.2)，没有特殊意义的保留字符需要预先编码，版本号中可能包含保留字符。
3. 未编码的"+"字符在后端将被解释为空格。