### PR TITLE
fix: oci仓库在http环境可能无法推送镜像 #999

### DIFF
--- a/src/backend/oci/biz-oci/src/main/kotlin/com/tencent/bkrepo/oci/config/OciProperties.kt
+++ b/src/backend/oci/biz-oci/src/main/kotlin/com/tencent/bkrepo/oci/config/OciProperties.kt
@@ -38,5 +38,5 @@ data class OciProperties(
 
     var domain: String = "localhost",
 
-    var https: Boolean = false
+    var scheme: String? = null
 )

--- a/src/backend/oci/biz-oci/src/main/kotlin/com/tencent/bkrepo/oci/service/impl/OciOperationServiceImpl.kt
+++ b/src/backend/oci/biz-oci/src/main/kotlin/com/tencent/bkrepo/oci/service/impl/OciOperationServiceImpl.kt
@@ -855,8 +855,8 @@ class OciOperationServiceImpl(
         logger.info("oci ociProperties ,${ociProperties}")
         return OciResponseUtils.getResponseURI(
             request = request,
-            enableHttps = ociProperties.https,
             domain = ociProperties.domain,
+            scheme = ociProperties.scheme
         ).toString()
     }
 

--- a/support-files/kubernetes/charts/bkrepo/templates/configmap-common.yaml
+++ b/support-files/kubernetes/charts/bkrepo/templates/configmap-common.yaml
@@ -26,10 +26,9 @@ data:
     service.prefix: {{ include "common.names.fullname" . }}-
     {{- if or .Values.ingress.tls .Values.forceHttps }}
     oci.authUrl: https://{{ include "bkrepo.oci.authUrl" . }}
-    oci.https: true
+    oci.scheme: https
     {{- else }}
     oci.authUrl: http://{{ include "bkrepo.oci.authUrl" . }}
-    oci.https: false
     {{- end }}
     {{- if and .Values.gateway.service.nodeIP (and .Values.gateway.service.dockerNodePort (or (eq .Values.gateway.service.type "NodePort") (eq .Values.gateway.service.type "LoadBalancer"))) }}
     oci.domain: {{ .Values.gateway.service.nodeIP }}:{{ .Values.gateway.service.dockerNodePort }}


### PR DESCRIPTION
issue:
1. #999

描述：
1. 使用`request.getHeader()`可以替代`request.getHeaders()`及其下方的 if-else 逻辑。
2. docker官方客户端发送请求时并不携带`X-Forwarded-Proto`请求头，如果网关转发请求时没有添加该请求头，当`oci.https==false`时，返回的location响应头的值仍然为https地址，导致在http环境下推送镜像失败。

对原本逻辑的影响：
1. 当`oci.https==true`时，与原本逻辑一致。
2. 当`oci.https==false`且缺少`X-Forwarded-Proto`请求头时，返回的响应头协议将变更为`http`；但如果客户端或网关传递了`X-Forwarded-Proto`请求头，则与原本逻辑一致。

