### PR TITLE
fix: oci指定端口号时无法推送镜像 #1694

### DIFF
--- a/src/backend/oci/biz-oci/src/main/kotlin/com/tencent/bkrepo/oci/util/OciResponseUtils.kt
+++ b/src/backend/oci/biz-oci/src/main/kotlin/com/tencent/bkrepo/oci/util/OciResponseUtils.kt
@@ -67,6 +67,7 @@ object OciResponseUtils {
     fun getResponseURI(request: HttpServletRequest, enableHttps: Boolean, domain: String): URI {
         val hostHeaders = request.getHeaders(HOST)
         var host = LOCAL_HOST
+        var port: Int? = null
         if (hostHeaders != null) {
             val headers = hostHeaders.toList()
             val parts = (headers[0] as String).split(":".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
@@ -74,9 +75,13 @@ object OciResponseUtils {
         }
         // domain为ip,port组合
         if (domain.split(":").size > 1) {
-            host = domain
+            host = domain.substringBeforeLast(":")
+            port = Integer.valueOf(domain.substringAfterLast(":"))
         }
         val builder = UriBuilder.fromPath(OCI_API_PREFIX).host(host).scheme(getProtocol(request, enableHttps))
+        port?.let {
+            builder.port(port)
+        }
         return builder.build()
     }
 


### PR DESCRIPTION
#### issue
1. #1694 

#### 描述
1. `UriBuilder.host()`方法会对传入的host进行url编码，当`oci.domain`为`<ip>:<port>`形式时，构建的`Uri`对象的`host`被编码为`<ip>%3A<port>`，导致`location`响应头的地址为`<scheme>:<ip>%3A<port>`。
2. docker客户端对`location`响应头进行转换([docker-ce](https://github.com/docker/docker-ce/blob/master/components/engine/vendor/github.com/containerd/containerd/remotes/docker/pusher.go#L231))，在转换过程中，使用go标准库`net/url`对`location`中的`host`进行url解码操作([net/url](https://github.com/golang/go/blob/master/src/net/url/url.go#L233-L234))。



3. 根据[RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.2)：
    > URI producing applications must not use percent-encoding in host unless it is used to represent a UTF-8 character sequence.

    在host中url编码仅可用于非ASC II 字符，而`:`(`%3A`)为ASC II字符。
    `net/url`的url解码操作遵循RFC 3986，在这种情况下将抛出`invalid URL escape "%3A"`错误给docker客户端。

#### 对原本逻辑的影响
1. 当domain包含端口号时，`builder.host()`传入的host与原本相比少了端口号，并额外执行`builder.port()`。