### PR TITLE
fix: oci远程仓库url包含命名空间时无法查询tags #1705

### DIFF
--- a/src/backend/oci/api-oci/src/main/kotlin/com/tencent/bkrepo/oci/pojo/artifact/OciArtifactInfo.kt
+++ b/src/backend/oci/api-oci/src/main/kotlin/com/tencent/bkrepo/oci/pojo/artifact/OciArtifactInfo.kt
@@ -61,12 +61,12 @@ open class OciArtifactInfo(
 
         // tags get
         const val TAGS_LIST_SUFFIX = "/tags/list"
+        const val TAGS_LIST_URL = "/v2/{projectId}/{repoName}/**/tags/list"
         // Retrieve a sorted, json list of repositories available in the registry.
         const val DOCKER_CATALOG_SUFFIX = "/v2/_catalog"
 
         // version详情获取
         const val OCI_VERSION_DETAIL = "/version/detail/{projectId}/{repoName}"
-
 
         // 额外的package或者version 删除接口
         const val OCI_PACKAGE_DELETE_URL = "/package/delete/{projectId}/{repoName}"

--- a/src/backend/oci/biz-oci/src/main/kotlin/com/tencent/bkrepo/oci/artifact/repository/OciRegistryRemoteRepository.kt
+++ b/src/backend/oci/biz-oci/src/main/kotlin/com/tencent/bkrepo/oci/artifact/repository/OciRegistryRemoteRepository.kt
@@ -63,7 +63,6 @@ import com.tencent.bkrepo.oci.constant.DOCKER_LINK
 import com.tencent.bkrepo.oci.constant.LAST_TAG
 import com.tencent.bkrepo.oci.constant.MEDIA_TYPE
 import com.tencent.bkrepo.oci.constant.N
-import com.tencent.bkrepo.oci.constant.OCI_API_PREFIX
 import com.tencent.bkrepo.oci.constant.OCI_FILTER_ENDPOINT
 import com.tencent.bkrepo.oci.constant.OCI_IMAGE_MANIFEST_MEDIA_TYPE
 import com.tencent.bkrepo.oci.constant.OciMessageCode
@@ -339,8 +338,9 @@ class OciRegistryRemoteRepository(
      */
     private fun createTagListUrl(property: RemoteRequestProperty): String {
         with(property) {
-            val url = UriBuilder.fromUri(url)
-                .path(OCI_API_PREFIX)
+            val baseUrl = URL(url)
+            val v2Url = URL(baseUrl, OCI_FILTER_ENDPOINT + baseUrl.path)
+            val url = UriBuilder.fromUri(v2Url.toString())
                 .path(imageName)
                 .path(TAGS_LIST_SUFFIX)
                 .build().toString()

--- a/src/backend/oci/biz-oci/src/main/kotlin/com/tencent/bkrepo/oci/artifact/resolver/OciTagArtifactInfoResolver.kt
+++ b/src/backend/oci/biz-oci/src/main/kotlin/com/tencent/bkrepo/oci/artifact/resolver/OciTagArtifactInfoResolver.kt
@@ -59,7 +59,7 @@ class OciTagArtifactInfoResolver : ArtifactInfoResolver {
         return when {
             requestURL.contains(TAGS_LIST_SUFFIX) -> {
                 val requestUrl = request.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE).toString()
-                val packageName = requestUrl.removePrefix("/$projectId/$repoName/v2/").removeSuffix(TAGS_LIST_SUFFIX)
+                val packageName = requestUrl.removePrefix("/v2/$projectId/$repoName/").removeSuffix(TAGS_LIST_SUFFIX)
                 validate(packageName)
                 val tag = request.getParameter(OCI_TAG) ?: StringPool.EMPTY
                 OciTagArtifactInfo(projectId, repoName, packageName, tag)

--- a/src/backend/oci/biz-oci/src/main/kotlin/com/tencent/bkrepo/oci/controller/user/OciTagController.kt
+++ b/src/backend/oci/biz-oci/src/main/kotlin/com/tencent/bkrepo/oci/controller/user/OciTagController.kt
@@ -31,15 +31,14 @@ import com.tencent.bkrepo.auth.pojo.enums.PermissionAction
 import com.tencent.bkrepo.auth.pojo.enums.ResourceType
 import com.tencent.bkrepo.common.security.permission.Permission
 import com.tencent.bkrepo.oci.constant.DOCKER_LINK
-import com.tencent.bkrepo.oci.pojo.artifact.OciArtifactInfo.Companion.TAGS_LIST_SUFFIX
+import com.tencent.bkrepo.oci.pojo.artifact.OciArtifactInfo.Companion.TAGS_LIST_URL
 import com.tencent.bkrepo.oci.pojo.artifact.OciTagArtifactInfo
 import com.tencent.bkrepo.oci.pojo.tags.TagsInfo
 import com.tencent.bkrepo.oci.service.OciTagService
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
@@ -52,7 +51,7 @@ class OciTagController(private val ociTagService: OciTagService) {
      * 获取blob对应的tag信息
      */
     @Permission(type = ResourceType.REPO, action = PermissionAction.READ)
-    @RequestMapping("/{projectId}/{repoName}/**$TAGS_LIST_SUFFIX", method = [RequestMethod.GET])
+    @GetMapping(TAGS_LIST_URL)
     fun getTagList(
         artifactInfo: OciTagArtifactInfo,
         @RequestParam n: Int?,


### PR DESCRIPTION
#### issue
1. #1705 

#### 描述
1. 当远程仓库的代理url包含命名空间时（例如`https://registry-1.docker.io/library`），`/v2/`被拼接在命名空间之后（`https://registry-1.docker.io/library/v2/{image}/tags/list`），导致查询不到`tags`。