### PR TITLE
fix: npm scope类型包的版本号解析错误 #1715

### DIFF
--- a/src/backend/npm/biz-npm/src/main/kotlin/com/tencent/bkrepo/npm/utils/NpmUtils.kt
+++ b/src/backend/npm/biz-npm/src/main/kotlin/com/tencent/bkrepo/npm/utils/NpmUtils.kt
@@ -63,7 +63,8 @@ object NpmUtils {
     }
 
     fun analyseVersionFromPackageName(filename: String, name: String): String {
-        return filename.substringBeforeLast(".tgz").substringAfter("$name-")
+        val unscopedName = name.substringAfterLast("/")
+        return filename.substringBeforeLast(".tgz").substringAfter("$unscopedName-")
     }
 
     /**


### PR DESCRIPTION
#### issue
1. #1715 

#### 描述
1. 包名格式为`@{scope}/{name}`的包，其文件名为`{name}-{version}.tgz`，此处逻辑不兼容这种格式的包名。