### PR TITLE
fix: 同步制品时保留manifestPath #1736

### DIFF
--- a/src/backend/replication/biz-replication/src/main/kotlin/com/tencent/bkrepo/replication/replica/replicator/standalone/ClusterReplicator.kt
+++ b/src/backend/replication/biz-replication/src/main/kotlin/com/tencent/bkrepo/replication/replica/replicator/standalone/ClusterReplicator.kt
@@ -186,7 +186,7 @@ class ClusterReplicator(
                 packageDescription = packageSummary.description,
                 versionName = packageVersion.name,
                 size = packageVersion.size,
-                manifestPath = null,
+                manifestPath = packageVersion.manifestPath,
                 artifactPath = packageVersion.contentPath,
                 stageTag = packageVersion.stageTag,
                 packageMetadata = packageMetadata,


### PR DESCRIPTION
#### issue
1. #1736

#### 描述
1.  当前仅npm和oci仓库制品的`manifestPath`不为`null`，目标节点创建分发版本时将`manifestPath`设置为`null`会导致使用`manifestPath`的一些功能出现问题。这两种仓库的manifest文件路径在源节点和目标节点是相同的。