### PR TITLE
feat: 新增适用于虚拟仓库的ArtifactContext复制方法 #1024

### DIFF
--- a/src/backend/common/common-artifact/artifact-api/build.gradle.kts
+++ b/src/backend/common/common-artifact/artifact-api/build.gradle.kts
@@ -33,4 +33,5 @@ dependencies {
     api(project(":common:common-api"))
     api("com.tencent.devops:devops-boot-starter-plugin")
     compileOnly("com.google.guava:guava")
+    implementation("org.apache.commons:commons-lang3")
 }

--- a/src/backend/common/common-artifact/artifact-api/src/main/kotlin/com/tencent/bkrepo/common/artifact/api/ArtifactInfo.kt
+++ b/src/backend/common/common-artifact/artifact-api/src/main/kotlin/com/tencent/bkrepo/common/artifact/api/ArtifactInfo.kt
@@ -34,6 +34,13 @@ package com.tencent.bkrepo.common.artifact.api
 import com.tencent.bkrepo.common.api.constant.CharPool.AT
 import com.tencent.bkrepo.common.api.constant.CharPool.SLASH
 import com.tencent.bkrepo.common.artifact.path.PathUtils
+import java.lang.reflect.InvocationTargetException
+import kotlin.reflect.KClass
+import kotlin.reflect.KMutableProperty
+import kotlin.reflect.KProperty1
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.full.primaryConstructor
+import kotlin.reflect.jvm.isAccessible
 
 /**
  * 构件信息
@@ -130,5 +137,55 @@ open class ArtifactInfo(
         builder.append(artifactName)
         getArtifactVersion()?.let { builder.append(AT).append(it) }
         return builder.toString()
+    }
+
+    /**
+     * 根据当前对象的属性值以及传入的[projectId]和[repoName]构造新的实例
+     * 非lateinit且不在构造函数中的属性需要覆写此方法单独赋值
+     */
+    @Suppress("UNCHECKED_CAST")
+    open fun copy(projectId: String? = null, repoName: String? = null): ArtifactInfo {
+        val constructor = this::class.primaryConstructor!!
+        val properties = (this::class as KClass<ArtifactInfo>).memberProperties
+        val paramMap = constructor.parameters.associateWith { param ->
+            when (param.name) {
+                ArtifactInfo::projectId.name -> projectId ?: this.projectId
+                ArtifactInfo::repoName.name -> repoName ?: this.repoName
+                ArtifactInfo::artifactUri.name -> this.artifactUri
+                else -> properties.find { it.name == param.name }?.let { getPropertyValue(it, this) }
+            }
+        }
+        val artifactInfo = constructor.callBy(paramMap)
+        // 构造实例后需要初始化lateinit属性
+        properties.filter { it.isLateinit }.forEach { property ->
+            try {
+                setPropertyValue(property, artifactInfo, getPropertyValue(property, this))
+            // 访问未初始化的lateinit属性时会捕获到该异常
+            } catch (ignore: UninitializedPropertyAccessException) { }
+        }
+        return artifactInfo
+    }
+
+    private fun getPropertyValue(property: KProperty1<ArtifactInfo, *>, target: ArtifactInfo): Any? {
+        return try {
+            if (property.isAccessible) property.get(target) else {
+                property.isAccessible = true
+                property.get(target).apply { property.isAccessible = false }
+            }
+        // 访问失败时捕获到该异常, 重新抛出封装在此的真实异常对象
+        } catch (ignore: InvocationTargetException) {
+            throw ignore.targetException
+        }
+    }
+
+    private fun setPropertyValue(property: KProperty1<ArtifactInfo, *>, target: ArtifactInfo, value: Any?) {
+        if (property is KMutableProperty<*>) {
+            if (property.isAccessible) {
+                property.setter.call(target, value)
+            } else {
+                property.isAccessible = true
+                property.setter.call(target, value).apply { property.isAccessible = false }
+            }
+        }
     }
 }

--- a/src/backend/common/common-artifact/artifact-service/src/main/kotlin/com/tencent/bkrepo/common/artifact/repository/context/ArtifactContext.kt
+++ b/src/backend/common/common-artifact/artifact-service/src/main/kotlin/com/tencent/bkrepo/common/artifact/repository/context/ArtifactContext.kt
@@ -46,6 +46,7 @@ import com.tencent.bkrepo.common.storage.credentials.StorageCredentials
 import com.tencent.bkrepo.repository.pojo.repo.RepositoryDetail
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
+import kotlin.reflect.full.primaryConstructor
 
 /**
  * 构件上下文
@@ -70,10 +71,27 @@ open class ArtifactContext(
     /**
      * 使用当前实例的属性，拷贝出一个新的[ArtifactContext]实例
      * 传入的[repositoryDetail]会替换当前实例的仓库信息
+     * 适用于CompositeRepository
      */
     fun copy(repositoryDetail: RepositoryDetail): ArtifactContext {
         val context = this.javaClass.newInstance()
         context.repositoryDetail = repositoryDetail
+        context.contextAttributes = this.contextAttributes
+        return context
+    }
+
+    /**
+     * 使用传入的[repositoryDetail]构造新的[ArtifactContext]实例
+     * [instantiation]: 实例化方法, 为null时使用主构造函数
+     * 适用于VirtualRepository: projectId, repoName, storageCredentials均会复制到新的实例, 并构造新的artifactInfo
+     */
+    open fun copy(
+        repositoryDetail: RepositoryDetail,
+        instantiation: ((ArtifactInfo) -> ArtifactContext)?
+    ): ArtifactContext {
+        val artifactInfo = this.artifactInfo.copy(repositoryDetail.projectId, repositoryDetail.name)
+        val context = instantiation?.invoke(artifactInfo)
+            ?: this::class.primaryConstructor!!.call(repositoryDetail, artifactInfo)
         context.contextAttributes = this.contextAttributes
         return context
     }

--- a/src/backend/common/common-artifact/artifact-service/src/main/kotlin/com/tencent/bkrepo/common/artifact/repository/context/ArtifactDownloadContext.kt
+++ b/src/backend/common/common-artifact/artifact-service/src/main/kotlin/com/tencent/bkrepo/common/artifact/repository/context/ArtifactDownloadContext.kt
@@ -41,6 +41,7 @@ import com.tencent.bkrepo.common.security.util.SecurityUtils
 import com.tencent.bkrepo.repository.pojo.node.NodeDetail
 import com.tencent.bkrepo.repository.pojo.packages.PackageVersion
 import com.tencent.bkrepo.repository.pojo.repo.RepositoryDetail
+import kotlin.reflect.full.primaryConstructor
 
 /**
  * 构件下载context
@@ -56,6 +57,17 @@ open class ArtifactDownloadContext(
     val repo = repo ?: request.getAttribute(REPO_KEY) as RepositoryDetail
     val artifacts = artifacts
     var shareUserId: String = StringPool.EMPTY
+
+    override fun copy(
+        repositoryDetail: RepositoryDetail,
+        instantiation: ((ArtifactInfo) -> ArtifactContext)?
+    ): ArtifactContext {
+        return super.copy(repositoryDetail) { artifactInfo ->
+            this::class.primaryConstructor!!.call(
+                repositoryDetail, artifactInfo, artifacts, this.userId, useDisposition
+            )
+        }
+    }
 
     @Suppress("UNCHECKED_CAST")
     fun getInterceptors(): List<DownloadInterceptor<*, NodeDetail>> {

--- a/src/backend/common/common-artifact/artifact-service/src/main/kotlin/com/tencent/bkrepo/common/artifact/repository/context/ArtifactQueryContext.kt
+++ b/src/backend/common/common-artifact/artifact-service/src/main/kotlin/com/tencent/bkrepo/common/artifact/repository/context/ArtifactQueryContext.kt
@@ -39,5 +39,5 @@ import com.tencent.bkrepo.repository.pojo.repo.RepositoryDetail
  */
 open class ArtifactQueryContext(
     repo: RepositoryDetail? = null,
-    artifact: ArtifactInfo? = null,
+    artifact: ArtifactInfo? = null
 ) : ArtifactContext(repo, artifact)

--- a/src/backend/common/common-artifact/artifact-service/src/main/kotlin/com/tencent/bkrepo/common/artifact/repository/context/ArtifactRemoveContext.kt
+++ b/src/backend/common/common-artifact/artifact-service/src/main/kotlin/com/tencent/bkrepo/common/artifact/repository/context/ArtifactRemoveContext.kt
@@ -31,7 +31,13 @@
 
 package com.tencent.bkrepo.common.artifact.repository.context
 
+import com.tencent.bkrepo.common.artifact.api.ArtifactInfo
+import com.tencent.bkrepo.repository.pojo.repo.RepositoryDetail
+
 /**
  * 构件删除context
  */
-open class ArtifactRemoveContext : ArtifactContext()
+open class ArtifactRemoveContext(
+    repo: RepositoryDetail? = null,
+    artifact: ArtifactInfo? = null
+) : ArtifactContext(repo, artifact)

--- a/src/backend/common/common-artifact/artifact-service/src/main/kotlin/com/tencent/bkrepo/common/artifact/repository/context/ArtifactSearchContext.kt
+++ b/src/backend/common/common-artifact/artifact-service/src/main/kotlin/com/tencent/bkrepo/common/artifact/repository/context/ArtifactSearchContext.kt
@@ -39,5 +39,5 @@ import com.tencent.bkrepo.repository.pojo.repo.RepositoryDetail
  */
 open class ArtifactSearchContext(
     repo: RepositoryDetail? = null,
-    artifact: ArtifactInfo? = null,
+    artifact: ArtifactInfo? = null
 ) : ArtifactContext(repo, artifact)

--- a/src/backend/common/common-artifact/artifact-service/src/main/kotlin/com/tencent/bkrepo/common/artifact/repository/context/ArtifactUploadContext.kt
+++ b/src/backend/common/common-artifact/artifact-service/src/main/kotlin/com/tencent/bkrepo/common/artifact/repository/context/ArtifactUploadContext.kt
@@ -68,6 +68,35 @@ open class ArtifactUploadContext : ArtifactContext {
         this.artifactFileMap = artifactFileMap
     }
 
+    constructor(
+        repo: RepositoryDetail,
+        artifactFileMap: ArtifactFileMap,
+        artifactInfo: ArtifactInfo? = null
+    ) : super(repo, artifactInfo) {
+        this.artifactFileMap = artifactFileMap
+    }
+
+    override fun copy(
+        repositoryDetail: RepositoryDetail,
+        instantiation: ((ArtifactInfo) -> ArtifactContext)?
+    ): ArtifactContext {
+        return super.copy(repositoryDetail) { artifactInfo ->
+            if (artifactFile != null) {
+                javaClass.getConstructor(
+                    RepositoryDetail::class.java,
+                    ArtifactFile::class.java,
+                    ArtifactInfo::class.java
+                ).newInstance(repositoryDetail, artifactFile, artifactInfo)
+            } else {
+                javaClass.getConstructor(
+                    RepositoryDetail::class.java,
+                    ArtifactFileMap::class.java,
+                    ArtifactInfo::class.java
+                ).newInstance(repositoryDetail, artifactFileMap, artifactInfo)
+            }
+        }
+    }
+
     /**
      * 根据[name]获取构件文件[ArtifactFile]
      *


### PR DESCRIPTION
#### issue
1. #1024 

#### 描述
1. 原有的`ArtifactContext.copy`方法不复制`projectId`、`repoName`、`storageCredentials`属性，仅适用于组合仓库。
2. 新增`ArtifactInfo.copy`方法，使用传入的`projectId`和`repoName`构造新实例，并复制其它所有属性。