### PR TITLE
fix: Generic远程仓库代理请求路径未编码 #2217

### DIFF
--- a/src/backend/generic/biz-generic/src/main/kotlin/com/tencent/bkrepo/generic/artifact/GenericRemoteRepository.kt
+++ b/src/backend/generic/biz-generic/src/main/kotlin/com/tencent/bkrepo/generic/artifact/GenericRemoteRepository.kt
@@ -34,6 +34,7 @@ package com.tencent.bkrepo.generic.artifact
 import com.tencent.bkrepo.common.api.constant.HttpHeaders
 import com.tencent.bkrepo.common.api.constant.HttpStatus
 import com.tencent.bkrepo.common.api.constant.MediaTypes
+import com.tencent.bkrepo.common.api.constant.urlEncode
 import com.tencent.bkrepo.common.api.exception.ErrorCodeException
 import com.tencent.bkrepo.common.api.message.CommonMessageCode.PARAMETER_INVALID
 import com.tencent.bkrepo.common.api.pojo.Page
@@ -128,6 +129,13 @@ class GenericRemoteRepository(
         }
     }
 
+    override fun createRemoteDownloadUrl(context: ArtifactContext): String {
+        val configuration = context.getRemoteConfiguration()
+        val artifactUri = context.artifactInfo.getArtifactFullPath().urlEncode()
+        val queryString = context.request.queryString
+        return UrlFormatter.format(configuration.url, artifactUri, queryString)
+    }
+
     override fun loadArtifactResource(cacheNode: NodeDetail, context: ArtifactDownloadContext): ArtifactResource? {
         val range = HttpContextHolder.getRequestOrNull()
             ?.let { resolveRange(it, cacheNode.size) }
@@ -194,7 +202,7 @@ class GenericRemoteRepository(
         val artifactInfo = context.artifactInfo
         val url = UrlFormatter.format(
             baseUrl,
-            "/generic/detail/$remoteProjectId/$remoteRepoName/${artifactInfo.getArtifactFullPath()}",
+            "/generic/detail/$remoteProjectId/$remoteRepoName/${artifactInfo.getArtifactFullPath().urlEncode()}",
         )
 
         // 执行请求

--- a/src/backend/generic/biz-generic/src/main/kotlin/com/tencent/bkrepo/generic/artifact/GenericRemoteRepository.kt
+++ b/src/backend/generic/biz-generic/src/main/kotlin/com/tencent/bkrepo/generic/artifact/GenericRemoteRepository.kt
@@ -151,7 +151,8 @@ class GenericRemoteRepository(
             if (logger.isDebugEnabled) {
                 logger.debug("Cached remote artifact[${context.artifactInfo}] is hit.")
             }
-            ArtifactResource(this, context.artifactInfo.getResponseName(), cacheNode, ArtifactChannel.PROXY)
+            val artifactName = context.artifactInfo.getResponseName()
+            ArtifactResource(this, artifactName, cacheNode, ArtifactChannel.PROXY, context.useDisposition)
         }
     }
 


### PR DESCRIPTION
1.  #2217 

        可能导致部分特定名称目录下的资源无法访问（例如META-INF目录）