### PR TITLE
fix: S3传输管理器的初始化方式线程不安全 #2344

### DIFF
--- a/src/backend/common/common-storage/storage-service/src/main/kotlin/com/tencent/bkrepo/common/storage/s3/S3Storage.kt
+++ b/src/backend/common/common-storage/storage-service/src/main/kotlin/com/tencent/bkrepo/common/storage/s3/S3Storage.kt
@@ -54,7 +54,7 @@ class S3Storage(
     private val executor: ThreadPoolTaskExecutor,
 ) : AbstractEncryptorFileStorage<S3Credentials, S3Client>() {
 
-    private var defaultTransferManager: TransferManager? = null
+    private val defaultTransferManager by lazy { createTransferManager(defaultClient) }
 
     override fun store(path: String, name: String, file: File, client: S3Client, storageClass: String?) {
         val transferManager = getTransferManager(client)
@@ -120,10 +120,7 @@ class S3Storage(
 
     private fun getTransferManager(client: S3Client): TransferManager {
         return if (client == defaultClient) {
-            if (defaultTransferManager == null) {
-                defaultTransferManager = createTransferManager(defaultClient)
-            }
-            defaultTransferManager!!
+            defaultTransferManager
         } else {
             createTransferManager(client)
         }


### PR DESCRIPTION
S3Storage的defaultTransferManager的初始化存在并发问题，可能会被重复初始化，并导致被错误关闭   #2344