### PR TITLE
fix: 仓库设置控制台报错,无法读取bkiamv3Check #2806

### DIFF
--- a/src/frontend/devops-repository/src/views/repoConfig/index.vue
+++ b/src/frontend/devops-repository/src/views/repoConfig/index.vue
@@ -156,7 +156,7 @@
                 return ['docker', 'generic', 'helm'].includes(this.repoType) && (this.userInfo.admin || this.userInfo.manage)
             },
             showControlConfigTab () {
-                return (this.userInfo.admin || this.userInfo.manage) && !this.authMode.bkiamv3Check
+                return (this.userInfo.admin || this.userInfo.manage) && (this.authMode && !this.authMode.bkiamv3Check)
             },
             repoAddress () {
                 const { repoType, name } = this.repoBaseInfo


### PR DESCRIPTION
authMode初始值为undefined，此值于created才赋予值，计算属性高于创建完属性，故会开始报一段错。