### PR TITLE
fix: 修复迁移失败Node时未正确判断node是否已归档 #3088

### DIFF
--- a/src/backend/common/common-metadata/metadata-service/src/main/kotlin/com/tencent/bkrepo/common/metadata/dao/node/NodeDao.kt
+++ b/src/backend/common/common-metadata/metadata-service/src/main/kotlin/com/tencent/bkrepo/common/metadata/dao/node/NodeDao.kt
@@ -43,6 +43,7 @@ import com.tencent.bkrepo.common.metadata.util.NodeQueryHelper
 import org.springframework.context.annotation.Conditional
 import org.springframework.data.domain.Page
 import org.springframework.data.mongodb.core.FindAndModifyOptions
+import org.springframework.data.mongodb.core.query.Criteria
 import org.springframework.data.mongodb.core.query.Query
 import org.springframework.data.mongodb.core.query.Update
 import org.springframework.data.mongodb.core.query.and
@@ -65,6 +66,13 @@ class NodeDao : HashShardingMongoDao<TNode>() {
         // 系统设计上不保存根目录节点到数据库，但是有用户会手动创建根目录节点
         return this.findOne(NodeQueryHelper.nodeQuery(projectId, repoName, fullPath))
             ?: if (PathUtils.isRoot(fullPath)) buildRootNode(projectId, repoName) else null
+    }
+
+    fun findNodeIncludeDeleted(projectId: String, repoName: String, fullPath: String): List<TNode> {
+        val criteria = Criteria.where(TNode::projectId.name).isEqualTo(projectId)
+            .and(TNode::repoName.name).isEqualTo(repoName)
+            .and(TNode::fullPath.name).isEqualTo(fullPath)
+        return find(Query(criteria))
     }
 
     /**

--- a/src/backend/job/biz-job/src/main/kotlin/com/tencent/bkrepo/job/controller/user/UserMigrateRepoStorageController.kt
+++ b/src/backend/job/biz-job/src/main/kotlin/com/tencent/bkrepo/job/controller/user/UserMigrateRepoStorageController.kt
@@ -131,9 +131,10 @@ class UserMigrateRepoStorageController(
      */
     @PostMapping("/archive/node/update")
     fun updateNodeArchiveStatus(
+        @RequestParam projectId: String,
         @RequestParam nodeId: String,
         @RequestParam(required = false, defaultValue = "true") archived: Boolean = true
     ) {
-        migrateFailedNodeService.updateNodeArchiveStatus(nodeId, archived)
+        migrateFailedNodeService.updateNodeArchiveStatus(projectId, nodeId, archived)
     }
 }

--- a/src/backend/job/biz-job/src/main/kotlin/com/tencent/bkrepo/job/controller/user/UserMigrateRepoStorageController.kt
+++ b/src/backend/job/biz-job/src/main/kotlin/com/tencent/bkrepo/job/controller/user/UserMigrateRepoStorageController.kt
@@ -117,4 +117,23 @@ class UserMigrateRepoStorageController(
     ) {
         migrateFailedNodeService.correctMigratedStorageFileReference(srcCredentialKey, dstCredentialKey)
     }
+
+    /**
+     * 修复缺失的失败节点
+     */
+    @PostMapping("/failed/node/fix/missing")
+    fun fixMissingFailedNode() {
+        migrateFailedNodeService.fixMissingFailedNode()
+    }
+
+    /**
+     * 更新node归档状态
+     */
+    @PostMapping("/archive/node/update")
+    fun updateNodeArchiveStatus(
+        @RequestParam nodeId: String,
+        @RequestParam(required = false, defaultValue = "true") archived: Boolean = true
+    ) {
+        migrateFailedNodeService.updateNodeArchiveStatus(nodeId, archived)
+    }
 }

--- a/src/backend/job/biz-job/src/main/kotlin/com/tencent/bkrepo/job/migrate/MigrateFailedNodeService.kt
+++ b/src/backend/job/biz-job/src/main/kotlin/com/tencent/bkrepo/job/migrate/MigrateFailedNodeService.kt
@@ -32,24 +32,35 @@ import com.tencent.bkrepo.common.api.constant.DEFAULT_PAGE_SIZE
 import com.tencent.bkrepo.common.api.exception.BadRequestException
 import com.tencent.bkrepo.common.api.exception.NotFoundException
 import com.tencent.bkrepo.common.api.message.CommonMessageCode
+import com.tencent.bkrepo.common.metadata.dao.node.NodeDao
 import com.tencent.bkrepo.common.metadata.dao.repo.RepositoryDao
 import com.tencent.bkrepo.common.metadata.model.TFileReference
+import com.tencent.bkrepo.common.metadata.model.TNode
 import com.tencent.bkrepo.common.metadata.service.file.FileReferenceService
 import com.tencent.bkrepo.common.metadata.service.repo.StorageCredentialService
+import com.tencent.bkrepo.common.mongo.constant.ID
 import com.tencent.bkrepo.common.mongo.dao.util.Pages
+import com.tencent.bkrepo.common.storage.config.StorageProperties
+import com.tencent.bkrepo.common.storage.core.StorageService
+import com.tencent.bkrepo.common.storage.credentials.StorageCredentials
 import com.tencent.bkrepo.job.BATCH_SIZE
 import com.tencent.bkrepo.job.batch.utils.NodeCommonUtils
+import com.tencent.bkrepo.job.batch.utils.RepositoryCommonUtils
 import com.tencent.bkrepo.job.migrate.dao.MigrateFailedNodeDao
 import com.tencent.bkrepo.job.migrate.dao.MigrateRepoStorageTaskDao
+import com.tencent.bkrepo.job.migrate.model.TMigrateFailedNode
 import com.tencent.bkrepo.job.migrate.model.TMigrateRepoStorageTask
 import com.tencent.bkrepo.job.migrate.pojo.MigrateRepoStorageTaskState
 import com.tencent.bkrepo.job.migrate.strategy.MigrateFailedNodeFixer
+import com.tencent.bkrepo.job.service.MigrateArchivedFileService
 import org.slf4j.LoggerFactory
 import org.springframework.data.mongodb.core.query.Criteria
 import org.springframework.data.mongodb.core.query.Query
+import org.springframework.data.mongodb.core.query.Update
 import org.springframework.data.mongodb.core.query.isEqualTo
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
+import java.time.LocalDateTime
 import java.util.concurrent.atomic.AtomicLong
 
 /**
@@ -63,6 +74,10 @@ class MigrateFailedNodeService(
     private val fileReferenceService: FileReferenceService,
     private val storageCredentialsService: StorageCredentialService,
     private val repositoryDao: RepositoryDao,
+    private val nodeDao: NodeDao,
+    private val storageService: StorageService,
+    private val migrateArchivedFileService: MigrateArchivedFileService,
+    private val storageProperties: StorageProperties,
 ) {
     /**
      * 无法处理时，或已经手动处理成功则可以移除迁移失败的node
@@ -147,6 +162,76 @@ class MigrateFailedNodeService(
                 fileReferenceService.increment(sha256, srcCredentialKey, -count)
             }
             logger.info("finish clean ref[$sha256], cleaned[${cleaned.incrementAndGet()}]")
+        }
+    }
+
+    /**
+     * 更新node归档状态
+     */
+    fun updateNodeArchiveStatus(nodeId: String, archived: Boolean = true) {
+        val update = Update().set(TNode::archived.name, archived)
+        nodeDao.updateFirst(Query(Criteria.where(ID).isEqualTo(nodeId)), update)
+        logger.info("set node $nodeId archived[$archived]")
+    }
+
+    /**
+     * 修复缺失的失败node
+     */
+    @Async
+    fun fixMissingFailedNode() {
+        logger.info("start fix missing failed node")
+        val taskCache = HashMap<String, TMigrateRepoStorageTask>()
+        migrateFailedNodeDao.iterate(null, null, null) { failedNode ->
+            val task = taskCache.getOrPut(failedNode.taskId) { migrateRepoStorageTaskDao.findById(failedNode.taskId)!! }
+            nodeDao.findNodeIncludeDeleted(failedNode.projectId, failedNode.repoName, failedNode.fullPath)
+                .distinctBy { it.sha256 }
+                .filter { it.sha256 != null && it.sha256 != failedNode.sha256 }
+                .forEach { node ->
+                    try {
+                        tryCreateFailedNodeFor(task, node)
+                    } catch (e: Exception) {
+                        logger.error("create failed node for [${node}] failed", e)
+                    }
+                }
+        }
+        logger.info("fix missing failed node finished")
+    }
+
+    private fun tryCreateFailedNodeFor(task: TMigrateRepoStorageTask, node: TNode) {
+        with(node) {
+            val fileExist = storageService.exist(sha256!!, getStorageCredentials(task.dstStorageKey))
+            val archivedFileExist = node.archived == true &&
+                    migrateArchivedFileService.archivedFileCompleted(task.dstStorageKey, sha256!!)
+            if (!fileExist && !archivedFileExist) {
+                val now = LocalDateTime.now()
+                migrateFailedNodeDao.insert(
+                    TMigrateFailedNode(
+                        id = null,
+                        createdDate = now,
+                        lastModifiedDate = now,
+                        nodeId = node.id!!,
+                        taskId = task.id!!,
+                        projectId = projectId,
+                        repoName = repoName,
+                        fullPath = fullPath,
+                        sha256 = sha256!!,
+                        md5 = md5!!,
+                        size = size,
+                        retryTimes = 0,
+                    )
+                )
+                logger.info("create failed node[$projectId/$repoName/$fullPath][$sha256] success")
+            } else {
+                logger.info("node[$projectId/$repoName/$fullPath][$sha256] already exists]")
+            }
+        }
+    }
+
+    private fun getStorageCredentials(key: String?): StorageCredentials {
+        return if (key == null) {
+            storageProperties.defaultStorageCredentials()
+        } else {
+            RepositoryCommonUtils.getStorageCredentials(key)!!
         }
     }
 

--- a/src/backend/job/biz-job/src/main/kotlin/com/tencent/bkrepo/job/migrate/dao/MigrateFailedNodeDao.kt
+++ b/src/backend/job/biz-job/src/main/kotlin/com/tencent/bkrepo/job/migrate/dao/MigrateFailedNodeDao.kt
@@ -29,9 +29,11 @@ package com.tencent.bkrepo.job.migrate.dao
 
 import com.mongodb.client.result.DeleteResult
 import com.mongodb.client.result.UpdateResult
+import com.tencent.bkrepo.common.mongo.constant.MIN_OBJECT_ID
 import com.tencent.bkrepo.common.mongo.dao.simple.SimpleMongoDao
 import com.tencent.bkrepo.job.migrate.Constant.MAX_MIGRATE_FAILED_RETRY_TIMES
 import com.tencent.bkrepo.job.migrate.model.TMigrateFailedNode
+import org.bson.types.ObjectId
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.data.mongodb.core.FindAndModifyOptions
@@ -47,6 +49,33 @@ class MigrateFailedNodeDao : SimpleMongoDao<TMigrateFailedNode>() {
     fun page(projectId: String, repoName: String, pageRequest: PageRequest): List<TMigrateFailedNode> {
         val criteria = buildCriteria(projectId, repoName)
         return find(Query(criteria).with(pageRequest))
+    }
+
+    fun iterate(
+        projectId: String?,
+        repoName: String?,
+        fullPath: String?,
+        consumer: (failedNode: TMigrateFailedNode) -> Unit
+    ) {
+        val criteria = Criteria()
+        projectId?.let { criteria.and(TMigrateFailedNode::projectId.name).isEqualTo(it) }
+        repoName?.let { criteria.and(TMigrateFailedNode::repoName.name).isEqualTo(it) }
+        fullPath?.let { criteria.and(TMigrateFailedNode::fullPath.name).isEqualTo(it) }
+        val query = Query(criteria)
+
+        var lastId = ObjectId(MIN_OBJECT_ID)
+        do {
+            val newQuery = Query.of(query)
+                .addCriteria(Criteria.where(ID).gt(lastId))
+                .limit(DEFAULT_BATCH_SIZE)
+                .with(Sort.by(ID).ascending())
+            val data = find(newQuery)
+            if (data.isEmpty()) {
+                break
+            }
+            data.forEach { consumer(it) }
+            lastId = ObjectId(data.last().id!!)
+        } while (data.size == DEFAULT_BATCH_SIZE)
     }
 
     fun findOneToRetry(
@@ -68,6 +97,10 @@ class MigrateFailedNodeDao : SimpleMongoDao<TMigrateFailedNode>() {
     fun existsFailedNode(projectId: String, repoName: String, fullPath: String? = null): Boolean {
         val criteria = buildCriteria(projectId, repoName, fullPath)
         return exists(Query(criteria))
+    }
+
+    fun existsFailedNode(nodeId: String): Boolean {
+        return exists(Query(TMigrateFailedNode::nodeId.isEqualTo(nodeId)))
     }
 
     fun existsRetryableNode(
@@ -103,5 +136,9 @@ class MigrateFailedNodeDao : SimpleMongoDao<TMigrateFailedNode>() {
             .and(TMigrateFailedNode::repoName.name).isEqualTo(repoName)
         fullPath?.let { criteria.and(TMigrateFailedNode::fullPath.name).isEqualTo(it) }
         return criteria
+    }
+
+    companion object {
+        private const val DEFAULT_BATCH_SIZE = 20
     }
 }

--- a/src/backend/job/biz-job/src/main/kotlin/com/tencent/bkrepo/job/migrate/executor/MigrateFailedNodeExecutor.kt
+++ b/src/backend/job/biz-job/src/main/kotlin/com/tencent/bkrepo/job/migrate/executor/MigrateFailedNodeExecutor.kt
@@ -45,7 +45,6 @@ import com.tencent.bkrepo.job.migrate.utils.MigrateRepoStorageUtils.buildThreadP
 import com.tencent.bkrepo.job.migrate.utils.TransferDataExecutor
 import com.tencent.bkrepo.job.service.MigrateArchivedFileService
 import org.slf4j.LoggerFactory
-import org.springframework.data.mongodb.core.query.Criteria
 import org.springframework.data.mongodb.core.query.Query
 import org.springframework.data.mongodb.core.query.isEqualTo
 import org.springframework.stereotype.Component
@@ -124,7 +123,8 @@ class MigrateFailedNodeExecutor(
     }
 
     private fun convert(failedNode: TMigrateFailedNode): Node {
-        val node = nodeDao.findOne(Query(Criteria.where(ID).isEqualTo(failedNode.nodeId)))
+        val criteria = Node::projectId.isEqualTo(failedNode.projectId).and(ID).isEqualTo(failedNode.nodeId)
+        val node = nodeDao.findOne(Query(criteria))
         return Node(
             id = failedNode.nodeId,
             projectId = failedNode.projectId,

--- a/src/backend/job/biz-job/src/main/kotlin/com/tencent/bkrepo/job/migrate/executor/MigrateFailedNodeExecutor.kt
+++ b/src/backend/job/biz-job/src/main/kotlin/com/tencent/bkrepo/job/migrate/executor/MigrateFailedNodeExecutor.kt
@@ -27,7 +27,9 @@
 
 package com.tencent.bkrepo.job.migrate.executor
 
+import com.tencent.bkrepo.common.metadata.dao.node.NodeDao
 import com.tencent.bkrepo.common.metadata.service.file.FileReferenceService
+import com.tencent.bkrepo.common.mongo.constant.ID
 import com.tencent.bkrepo.common.storage.core.StorageService
 import com.tencent.bkrepo.job.migrate.Constant.MAX_MIGRATE_FAILED_RETRY_TIMES
 import com.tencent.bkrepo.job.migrate.config.MigrateRepoStorageProperties
@@ -43,6 +45,9 @@ import com.tencent.bkrepo.job.migrate.utils.MigrateRepoStorageUtils.buildThreadP
 import com.tencent.bkrepo.job.migrate.utils.TransferDataExecutor
 import com.tencent.bkrepo.job.service.MigrateArchivedFileService
 import org.slf4j.LoggerFactory
+import org.springframework.data.mongodb.core.query.Criteria
+import org.springframework.data.mongodb.core.query.Query
+import org.springframework.data.mongodb.core.query.isEqualTo
 import org.springframework.stereotype.Component
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
@@ -58,6 +63,7 @@ class MigrateFailedNodeExecutor(
     migrateArchivedFileService: MigrateArchivedFileService,
     private val transferDataExecutor: TransferDataExecutor,
     private val migrateFailedNodeFixer: MigrateFailedNodeFixer,
+    private val nodeDao: NodeDao,
 ) : BaseTaskExecutor(
     properties,
     migrateRepoStorageTaskDao,
@@ -117,15 +123,20 @@ class MigrateFailedNodeExecutor(
         }
     }
 
-    private fun convert(failedNode: TMigrateFailedNode) = Node(
-        id = failedNode.nodeId,
-        projectId = failedNode.projectId,
-        repoName = failedNode.repoName,
-        fullPath = failedNode.fullPath,
-        size = failedNode.size,
-        sha256 = failedNode.sha256,
-        md5 = failedNode.md5,
-    )
+    private fun convert(failedNode: TMigrateFailedNode): Node {
+        val node = nodeDao.findOne(Query(Criteria.where(ID).isEqualTo(failedNode.nodeId)))
+        return Node(
+            id = failedNode.nodeId,
+            projectId = failedNode.projectId,
+            repoName = failedNode.repoName,
+            fullPath = failedNode.fullPath,
+            size = failedNode.size,
+            sha256 = failedNode.sha256,
+            md5 = failedNode.md5,
+            archived = node?.archived,
+            compressed = node?.compressed,
+        )
+    }
 
     companion object {
         private val logger = LoggerFactory.getLogger(MigrateFailedNodeExecutor::class.java)

--- a/src/backend/job/biz-job/src/main/kotlin/com/tencent/bkrepo/job/migrate/executor/handler/DefaultMigrateFailedHandler.kt
+++ b/src/backend/job/biz-job/src/main/kotlin/com/tencent/bkrepo/job/migrate/executor/handler/DefaultMigrateFailedHandler.kt
@@ -52,12 +52,13 @@ class DefaultMigrateFailedHandler(
     }
 
     private fun saveMigrateFailedNode(taskId: String, node: Node) {
-        if (migrateFailedNodeDao.existsFailedNode(node.id)) {
-            return
-        }
-
-        val now = LocalDateTime.now()
         with(node) {
+            if (migrateFailedNodeDao.existsFailedNode(id)) {
+                logger.info("failed node[${projectId}/${repoName}${fullPath}] already exists, nodeId[${id}]")
+                return
+            }
+
+            val now = LocalDateTime.now()
             try {
                 migrateFailedNodeDao.insert(
                     TMigrateFailedNode(
@@ -72,9 +73,10 @@ class DefaultMigrateFailedHandler(
                         sha256 = sha256,
                         md5 = md5,
                         size = size,
-                        retryTimes = 0
+                        retryTimes = 0,
                     )
                 )
+                logger.info("insert failed node[${projectId}/${repoName}${fullPath}] success")
             } catch (ignore: DuplicateKeyException) {
                 logger.warn("duplicate failed node[$node]", ignore)
             }

--- a/src/backend/job/biz-job/src/main/kotlin/com/tencent/bkrepo/job/migrate/executor/handler/DefaultMigrateFailedHandler.kt
+++ b/src/backend/job/biz-job/src/main/kotlin/com/tencent/bkrepo/job/migrate/executor/handler/DefaultMigrateFailedHandler.kt
@@ -52,7 +52,7 @@ class DefaultMigrateFailedHandler(
     }
 
     private fun saveMigrateFailedNode(taskId: String, node: Node) {
-        if (migrateFailedNodeDao.existsFailedNode(node.projectId, node.repoName, node.fullPath)) {
+        if (migrateFailedNodeDao.existsFailedNode(node.id)) {
             return
         }
 
@@ -76,6 +76,7 @@ class DefaultMigrateFailedHandler(
                     )
                 )
             } catch (ignore: DuplicateKeyException) {
+                logger.warn("duplicate failed node[$node]", ignore)
             }
         }
     }

--- a/src/backend/job/biz-job/src/main/kotlin/com/tencent/bkrepo/job/migrate/model/TMigrateFailedNode.kt
+++ b/src/backend/job/biz-job/src/main/kotlin/com/tencent/bkrepo/job/migrate/model/TMigrateFailedNode.kt
@@ -27,8 +27,10 @@
 
 package com.tencent.bkrepo.job.migrate.model
 
-import com.tencent.bkrepo.job.migrate.model.TMigrateFailedNode.Companion.FULL_PATH_IDX
-import com.tencent.bkrepo.job.migrate.model.TMigrateFailedNode.Companion.FULL_PATH_IDX_DEF
+import com.tencent.bkrepo.job.migrate.model.TMigrateFailedNode.Companion.NEW_FULL_PATH_IDX
+import com.tencent.bkrepo.job.migrate.model.TMigrateFailedNode.Companion.NEW_FULL_PATH_IDX_DEF
+import com.tencent.bkrepo.job.migrate.model.TMigrateFailedNode.Companion.NODE_ID_IDX
+import com.tencent.bkrepo.job.migrate.model.TMigrateFailedNode.Companion.NODE_ID_IDX_DEF
 import org.springframework.data.mongodb.core.index.CompoundIndex
 import org.springframework.data.mongodb.core.index.CompoundIndexes
 import org.springframework.data.mongodb.core.mapping.Document
@@ -36,7 +38,8 @@ import java.time.LocalDateTime
 
 @Document("migrate_failed_node")
 @CompoundIndexes(
-    CompoundIndex(name = FULL_PATH_IDX, def = FULL_PATH_IDX_DEF, unique = true)
+    CompoundIndex(name = NEW_FULL_PATH_IDX, def = NEW_FULL_PATH_IDX_DEF, background = true),
+    CompoundIndex(name = NODE_ID_IDX, def = NODE_ID_IDX_DEF, unique = true, background = true)
 )
 data class TMigrateFailedNode(
     val id: String? = null,
@@ -67,7 +70,9 @@ data class TMigrateFailedNode(
     val migrating: Boolean = false,
 ) {
     companion object {
-        const val FULL_PATH_IDX = "projectId_repoName_fullPath_idx"
-        const val FULL_PATH_IDX_DEF = "{'projectId': 1, 'repoName': 1, 'fullPath': 1}"
+        const val NEW_FULL_PATH_IDX = "projectId_repoName_fullPath_retryTimes_idx"
+        const val NEW_FULL_PATH_IDX_DEF = "{'projectId': 1, 'repoName': 1, 'fullPath': 1, 'retryTimes': 1}"
+        const val NODE_ID_IDX = "nodeId_idx"
+        const val NODE_ID_IDX_DEF = "{'nodeId': 1}"
     }
 }

--- a/src/backend/job/biz-job/src/test/kotlin/com/tencent/bkrepo/job/migrate/MigrateFailedNodeServiceTest.kt
+++ b/src/backend/job/biz-job/src/test/kotlin/com/tencent/bkrepo/job/migrate/MigrateFailedNodeServiceTest.kt
@@ -1,11 +1,14 @@
 package com.tencent.bkrepo.job.migrate
 
 import com.tencent.bkrepo.common.metadata.dao.file.FileReferenceDao
+import com.tencent.bkrepo.common.metadata.dao.node.NodeDao
 import com.tencent.bkrepo.common.metadata.dao.repo.RepositoryDao
 import com.tencent.bkrepo.common.metadata.service.file.FileReferenceService
 import com.tencent.bkrepo.common.metadata.service.file.impl.FileReferenceServiceImpl
 import com.tencent.bkrepo.common.metadata.service.repo.StorageCredentialService
 import com.tencent.bkrepo.common.mongo.constant.ID
+import com.tencent.bkrepo.common.storage.config.StorageProperties
+import com.tencent.bkrepo.common.storage.core.StorageService
 import com.tencent.bkrepo.common.storage.credentials.FileSystemCredentials
 import com.tencent.bkrepo.job.UT_PROJECT_ID
 import com.tencent.bkrepo.job.UT_REPO_NAME
@@ -21,6 +24,7 @@ import com.tencent.bkrepo.job.migrate.strategy.MigrateFailedNodeAutoFixStrategy
 import com.tencent.bkrepo.job.migrate.strategy.MigrateFailedNodeFixer
 import com.tencent.bkrepo.job.migrate.utils.MigrateTestUtils.insertFailedNode
 import com.tencent.bkrepo.job.separation.service.SeparationTaskService
+import com.tencent.bkrepo.job.service.MigrateArchivedFileService
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.BeforeAll
@@ -54,6 +58,8 @@ import java.time.LocalDateTime
     FileReferenceServiceImpl::class,
     FileReferenceDao::class,
     RepositoryDao::class,
+    NodeDao::class,
+    StorageProperties::class,
 )
 @TestPropertySource(locations = ["classpath:bootstrap-ut.properties"])
 class MigrateFailedNodeServiceTest @Autowired constructor(
@@ -76,6 +82,12 @@ class MigrateFailedNodeServiceTest @Autowired constructor(
 
     @MockBean
     private lateinit var storageCredentialService: StorageCredentialService
+
+    @MockBean
+    private lateinit var storageService: StorageService
+
+    @MockBean
+    private lateinit var migrateArchivedFileService: MigrateArchivedFileService
 
     @BeforeAll
     fun beforeAll() {

--- a/src/backend/job/biz-job/src/test/kotlin/com/tencent/bkrepo/job/migrate/MigrateFailedNodeServiceTest.kt
+++ b/src/backend/job/biz-job/src/test/kotlin/com/tencent/bkrepo/job/migrate/MigrateFailedNodeServiceTest.kt
@@ -5,6 +5,7 @@ import com.tencent.bkrepo.common.metadata.dao.node.NodeDao
 import com.tencent.bkrepo.common.metadata.dao.repo.RepositoryDao
 import com.tencent.bkrepo.common.metadata.service.file.FileReferenceService
 import com.tencent.bkrepo.common.metadata.service.file.impl.FileReferenceServiceImpl
+import com.tencent.bkrepo.common.metadata.service.repo.RepositoryService
 import com.tencent.bkrepo.common.metadata.service.repo.StorageCredentialService
 import com.tencent.bkrepo.common.mongo.constant.ID
 import com.tencent.bkrepo.common.storage.config.StorageProperties
@@ -12,9 +13,11 @@ import com.tencent.bkrepo.common.storage.core.StorageService
 import com.tencent.bkrepo.common.storage.credentials.FileSystemCredentials
 import com.tencent.bkrepo.job.UT_PROJECT_ID
 import com.tencent.bkrepo.job.UT_REPO_NAME
+import com.tencent.bkrepo.job.UT_SHA256
 import com.tencent.bkrepo.job.UT_STORAGE_CREDENTIALS_KEY
 import com.tencent.bkrepo.job.UT_USER
 import com.tencent.bkrepo.job.batch.utils.NodeCommonUtils
+import com.tencent.bkrepo.job.batch.utils.RepositoryCommonUtils
 import com.tencent.bkrepo.job.migrate.dao.MigrateFailedNodeDao
 import com.tencent.bkrepo.job.migrate.dao.MigrateRepoStorageTaskDao
 import com.tencent.bkrepo.job.migrate.model.TMigrateFailedNode
@@ -22,6 +25,7 @@ import com.tencent.bkrepo.job.migrate.model.TMigrateRepoStorageTask
 import com.tencent.bkrepo.job.migrate.pojo.MigrateRepoStorageTaskState
 import com.tencent.bkrepo.job.migrate.strategy.MigrateFailedNodeAutoFixStrategy
 import com.tencent.bkrepo.job.migrate.strategy.MigrateFailedNodeFixer
+import com.tencent.bkrepo.job.migrate.utils.MigrateTestUtils.createNode
 import com.tencent.bkrepo.job.migrate.utils.MigrateTestUtils.insertFailedNode
 import com.tencent.bkrepo.job.separation.service.SeparationTaskService
 import com.tencent.bkrepo.job.service.MigrateArchivedFileService
@@ -32,6 +36,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.mockito.ArgumentMatchers.anyString
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.whenever
@@ -45,6 +50,7 @@ import org.springframework.data.mongodb.core.query.Query
 import org.springframework.data.mongodb.core.query.Update
 import org.springframework.data.mongodb.core.query.isEqualTo
 import org.springframework.test.context.TestPropertySource
+import java.time.Duration
 import java.time.LocalDateTime
 
 @DisplayName("迁移失败节点服务测试")
@@ -60,6 +66,7 @@ import java.time.LocalDateTime
     RepositoryDao::class,
     NodeDao::class,
     StorageProperties::class,
+    RepositoryCommonUtils::class,
 )
 @TestPropertySource(locations = ["classpath:bootstrap-ut.properties"])
 class MigrateFailedNodeServiceTest @Autowired constructor(
@@ -67,6 +74,7 @@ class MigrateFailedNodeServiceTest @Autowired constructor(
     private val migrateFailedNodeDao: MigrateFailedNodeDao,
     private val fileReferenceService: FileReferenceService,
     private val mongoTemplate: MongoTemplate,
+    private val nodeDao: NodeDao,
 ) {
     @Autowired
     private lateinit var migrateRepoStorageTaskDao: MigrateRepoStorageTaskDao
@@ -88,6 +96,12 @@ class MigrateFailedNodeServiceTest @Autowired constructor(
 
     @MockBean
     private lateinit var migrateArchivedFileService: MigrateArchivedFileService
+
+    @MockBean
+    private lateinit var repositoryService: RepositoryService
+
+    @Autowired
+    private lateinit var repositoryCommonUtils: RepositoryCommonUtils
 
     @BeforeAll
     fun beforeAll() {
@@ -253,5 +267,65 @@ class MigrateFailedNodeServiceTest @Autowired constructor(
 
         // other credentials
         test("test-src2", "test-dst2")
+    }
+
+    @Test
+    fun testFixMissingFailedNode() {
+        val now = LocalDateTime.now()
+        migrateRepoStorageTaskDao.insert(
+            TMigrateRepoStorageTask(
+                id = "",
+                createdBy = UT_USER,
+                createdDate = now,
+                lastModifiedBy = UT_USER,
+                lastModifiedDate = now,
+                startDate = now,
+                totalCount = 4,
+                migratedCount = 4,
+                lastMigratedNodeId = "",
+                projectId = UT_PROJECT_ID,
+                repoName = UT_REPO_NAME,
+                srcStorageKey = null,
+                dstStorageKey = UT_STORAGE_CREDENTIALS_KEY,
+                state = MigrateRepoStorageTaskState.MIGRATING_FAILED_NODE.name,
+            )
+        )
+        migrateFailedNodeDao.insertFailedNode()
+        nodeDao.createNode(sha256 = UT_SHA256)
+        nodeDao.createNode(
+            sha256 = "688787d8ff144c502c7f5cffaafe2cc588d86079f9de88304c26b0cb99ce91c1",
+            deleted = LocalDateTime.now().minus(Duration.ofMinutes(1L)),
+        )
+        nodeDao.createNode(
+            sha256 = "688787d8ff144c502c7f5cffaafe2cc588d86079f9de88304c26b0cb99ce91c2",
+            deleted = LocalDateTime.now().minus(Duration.ofMinutes(2L)),
+            archived = true
+        )
+        nodeDao.createNode(
+            sha256 = "688787d8ff144c502c7f5cffaafe2cc588d86079f9de88304c26b0cb99ce91c2",
+            deleted = LocalDateTime.now().minus(Duration.ofMinutes(3L)),
+        )
+        nodeDao.createNode(
+            sha256 = "688787d8ff144c502c7f5cffaafe2cc588d86079f9de88304c26b0cb99ce91c2",
+            fullPath = "/a/b/d.txt",
+            deleted = LocalDateTime.now().minus(Duration.ofMinutes(3L)),
+        )
+        assertEquals(1L, migrateFailedNodeDao.count(Query()))
+
+        whenever(storageService.exist(anyString(), anyOrNull())).thenReturn(false)
+        whenever(migrateArchivedFileService.archivedFileCompleted(anyOrNull(), anyString())).thenReturn(false)
+        migrateFailedNodeService.fixMissingFailedNode()
+        Thread.sleep(1000L)
+        assertEquals(3L, migrateFailedNodeDao.count(Query()))
+    }
+
+    @Test
+    fun testUpdateNodeArchived() {
+        val node = nodeDao.createNode()
+        assertEquals(false, node.archived)
+        migrateFailedNodeService.updateNodeArchiveStatus(node.projectId, node.id!!, true)
+        assertEquals(true, nodeDao.findNode(node.projectId, node.repoName, node.fullPath)!!.archived)
+        migrateFailedNodeService.updateNodeArchiveStatus(node.projectId, node.id!!, false)
+        assertEquals(false, nodeDao.findNode(node.projectId, node.repoName, node.fullPath)!!.archived)
     }
 }

--- a/src/backend/job/biz-job/src/test/kotlin/com/tencent/bkrepo/job/migrate/MigrateFailedNodeServiceTest.kt
+++ b/src/backend/job/biz-job/src/test/kotlin/com/tencent/bkrepo/job/migrate/MigrateFailedNodeServiceTest.kt
@@ -3,6 +3,7 @@ package com.tencent.bkrepo.job.migrate
 import com.tencent.bkrepo.common.metadata.dao.file.FileReferenceDao
 import com.tencent.bkrepo.common.metadata.dao.node.NodeDao
 import com.tencent.bkrepo.common.metadata.dao.repo.RepositoryDao
+import com.tencent.bkrepo.common.metadata.model.TNode
 import com.tencent.bkrepo.common.metadata.service.file.FileReferenceService
 import com.tencent.bkrepo.common.metadata.service.file.impl.FileReferenceServiceImpl
 import com.tencent.bkrepo.common.metadata.service.repo.RepositoryService
@@ -116,6 +117,7 @@ class MigrateFailedNodeServiceTest @Autowired constructor(
         whenever(autoFixStrategy.fix(any())).thenReturn(true)
         migrateFailedNodeDao.remove(Query())
         migrateRepoStorageTaskDao.remove(Query())
+        nodeDao.remove(Query(TNode::projectId.isEqualTo(UT_PROJECT_ID)))
     }
 
     @Test

--- a/src/backend/job/biz-job/src/test/kotlin/com/tencent/bkrepo/job/migrate/executor/ExecutorBaseTest.kt
+++ b/src/backend/job/biz-job/src/test/kotlin/com/tencent/bkrepo/job/migrate/executor/ExecutorBaseTest.kt
@@ -27,6 +27,7 @@
 
 package com.tencent.bkrepo.job.migrate.executor
 
+import com.tencent.bkrepo.common.metadata.dao.node.NodeDao
 import com.tencent.bkrepo.common.metadata.service.file.FileReferenceService
 import com.tencent.bkrepo.common.metadata.service.repo.RepositoryService
 import com.tencent.bkrepo.common.metadata.service.repo.StorageCredentialService
@@ -77,6 +78,7 @@ import java.time.LocalDateTime
     MigrateRepoStorageProperties::class,
     RepositoryCommonUtils::class,
     StorageProperties::class,
+    NodeDao::class
 )
 @ComponentScan(basePackages = ["com.tencent.bkrepo.job.migrate"])
 @TestPropertySource(locations = ["classpath:bootstrap-ut.properties"])

--- a/src/backend/job/biz-job/src/test/kotlin/com/tencent/bkrepo/job/migrate/executor/MigrateExecutorTest.kt
+++ b/src/backend/job/biz-job/src/test/kotlin/com/tencent/bkrepo/job/migrate/executor/MigrateExecutorTest.kt
@@ -10,6 +10,7 @@ import com.tencent.bkrepo.job.migrate.pojo.MigrateRepoStorageTask.Companion.toDt
 import com.tencent.bkrepo.job.migrate.pojo.MigrateRepoStorageTaskState
 import com.tencent.bkrepo.job.migrate.pojo.Node
 import com.tencent.bkrepo.job.migrate.utils.MigrateTestUtils.createNode
+import com.tencent.bkrepo.job.migrate.utils.MigrateTestUtils.insertFailedNode
 import com.tencent.bkrepo.job.migrate.utils.MigrateTestUtils.removeNodes
 import com.tencent.bkrepo.job.model.TNode
 import org.junit.jupiter.api.AfterAll
@@ -119,12 +120,14 @@ class MigrateExecutorTest @Autowired constructor(
         mongoTemplate.createNode()
         mongoTemplate.createNode(sha256 = FAKE_SHA256, fullPath = "/a/b/d.txt")
         mongoTemplate.createNode(compressed = true, fullPath = "/a/b/e.txt")
+        val node = mongoTemplate.createNode(fullPath = "/a/b/f.txt")
+        migrateFailedNodeDao.insertFailedNode(nodeId = node.id!!)
         val context = executor.execute(buildContext(createTask()))!!
 
         // 等待任务执行完
         Thread.sleep(1000L)
         context.waitAllTransferFinished()
-        assertEquals(3, migrateFailedNodeDao.count(Query()))
+        assertEquals(4, migrateFailedNodeDao.count(Query()))
     }
 
     @Test

--- a/src/backend/job/biz-job/src/test/kotlin/com/tencent/bkrepo/job/migrate/executor/MigrateExecutorTest.kt
+++ b/src/backend/job/biz-job/src/test/kotlin/com/tencent/bkrepo/job/migrate/executor/MigrateExecutorTest.kt
@@ -51,6 +51,7 @@ class MigrateExecutorTest @Autowired constructor(
     fun beforeEach() {
         initMock()
         migrateRepoStorageTaskDao.remove(Query())
+        migrateFailedNodeDao.remove(Query())
         mongoTemplate.removeNodes()
     }
 

--- a/src/backend/job/biz-job/src/test/kotlin/com/tencent/bkrepo/job/migrate/utils/MigrateTestUtils.kt
+++ b/src/backend/job/biz-job/src/test/kotlin/com/tencent/bkrepo/job/migrate/utils/MigrateTestUtils.kt
@@ -34,6 +34,7 @@ import com.tencent.bkrepo.archive.repository.ArchiveFileDao
 import com.tencent.bkrepo.common.artifact.pojo.RepositoryCategory
 import com.tencent.bkrepo.common.artifact.pojo.RepositoryType
 import com.tencent.bkrepo.common.artifact.pojo.configuration.local.LocalConfiguration
+import com.tencent.bkrepo.common.metadata.dao.node.NodeDao
 import com.tencent.bkrepo.common.metadata.service.repo.RepositoryService
 import com.tencent.bkrepo.common.metadata.service.repo.StorageCredentialService
 import com.tencent.bkrepo.common.mongo.dao.util.sharding.HashShardingUtils
@@ -101,14 +102,17 @@ object MigrateTestUtils {
         storageCredentials = storageCredentials,
     )
 
-    fun MigrateFailedNodeDao.insertFailedNode(fullPath: String = "/a/b/c.txt"): TMigrateFailedNode {
+    fun MigrateFailedNodeDao.insertFailedNode(
+        fullPath: String = "/a/b/c.txt",
+        nodeId: String = ""
+    ): TMigrateFailedNode {
         val now = LocalDateTime.now()
         return insert(
             TMigrateFailedNode(
                 id = null,
                 createdDate = now,
                 lastModifiedDate = now,
-                nodeId = "",
+                nodeId = nodeId,
                 taskId = "",
                 projectId = UT_PROJECT_ID,
                 repoName = UT_REPO_NAME,
@@ -146,6 +150,38 @@ object MigrateTestUtils {
         val collectionName = "node_$sharding"
         ensureNodeIndex(collectionName)
         return insert(node, collectionName)
+    }
+
+    fun NodeDao.createNode(
+        projectId: String = UT_PROJECT_ID,
+        repoName: String = UT_REPO_NAME,
+        fullPath: String = "/a/b/c.txt",
+        sha256: String = UT_SHA256,
+        archived: Boolean = false,
+        compressed: Boolean = false,
+        deleted: LocalDateTime? = null,
+    ): com.tencent.bkrepo.common.metadata.model.TNode {
+        val now = LocalDateTime.now()
+        val node = com.tencent.bkrepo.common.metadata.model.TNode(
+            id = null,
+            projectId = projectId,
+            repoName = repoName,
+            fullPath = fullPath,
+            createdBy = UT_USER,
+            createdDate = now,
+            lastModifiedBy = UT_USER,
+            lastModifiedDate = now,
+            name = "",
+            path = "",
+            size = 100L,
+            sha256 = sha256,
+            md5 = UT_MD5,
+            folder = false,
+            archived = archived,
+            compressed = compressed,
+            deleted = deleted,
+        )
+        return insert(node)
     }
 
     fun MongoTemplate.ensureNodeIndex(collectionName: String) {


### PR DESCRIPTION
issue:  #3088 

1. 修复存在同路径已删除node迁移失败时无法保存failedNode，支持手动创建缺失的failedNode
2. 支持更新node归档状态
3. 修复迁移失败Node时未正确判断node是否已归档