### PR TITLE
fix: oci远程仓库代理部分镜像源认证失败 #3257

### DIFF
--- a/src/backend/common/common-api/src/main/kotlin/com/tencent/bkrepo/common/api/util/AuthenticationUtil.kt
+++ b/src/backend/common/common-api/src/main/kotlin/com/tencent/bkrepo/common/api/util/AuthenticationUtil.kt
@@ -44,8 +44,8 @@ object AuthenticationUtil {
             val params = wwwAuthenticate.split("\",")
             params.forEach {
                 val param = it.split(Regex("="),2)
-                val name = param.first()
-                val value = param.last().replace("\"", "")
+                val name = param.first().trim()
+                val value = param.last().trim().replace("\"", "")
                 map[name] = value
             }
             AuthenticationProperty(


### PR DESCRIPTION
1. #3257