### PR TITLE
fix: 修复下载forwardNode时候返回的checksum错误 #3469

### DIFF
--- a/src/backend/common/common-artifact/artifact-service/src/main/kotlin/com/tencent/bkrepo/common/artifact/repository/context/ArtifactContextHolder.kt
+++ b/src/backend/common/common-artifact/artifact-service/src/main/kotlin/com/tencent/bkrepo/common/artifact/repository/context/ArtifactContextHolder.kt
@@ -32,6 +32,7 @@
 package com.tencent.bkrepo.common.artifact.repository.context
 
 import com.google.common.cache.CacheBuilder
+import com.tencent.bk.audit.context.ActionAuditContext
 import com.tencent.bkrepo.common.api.constant.CharPool
 import com.tencent.bkrepo.common.artifact.api.ArtifactInfo
 import com.tencent.bkrepo.common.artifact.config.ArtifactConfigurer
@@ -43,6 +44,7 @@ import com.tencent.bkrepo.common.artifact.constant.REPO_KEY
 import com.tencent.bkrepo.common.artifact.constant.REPO_NAME
 import com.tencent.bkrepo.common.artifact.constant.REPO_RATE_LIMIT_KEY
 import com.tencent.bkrepo.common.artifact.exception.RepoNotFoundException
+import com.tencent.bkrepo.common.artifact.manager.NodeForwardService
 import com.tencent.bkrepo.common.artifact.pojo.RepositoryCategory
 import com.tencent.bkrepo.common.artifact.pojo.RepositoryId
 import com.tencent.bkrepo.common.artifact.pojo.RepositoryType
@@ -50,11 +52,14 @@ import com.tencent.bkrepo.common.artifact.repository.composite.CompositeReposito
 import com.tencent.bkrepo.common.artifact.repository.core.ArtifactRepository
 import com.tencent.bkrepo.common.artifact.repository.proxy.ProxyRepository
 import com.tencent.bkrepo.common.security.http.core.HttpAuthSecurity
+import com.tencent.bkrepo.common.security.util.SecurityUtils
 import com.tencent.bkrepo.common.service.util.HttpContextHolder
 import com.tencent.bkrepo.common.storage.config.RateLimitProperties
+import com.tencent.bkrepo.common.storage.credentials.StorageCredentials
 import com.tencent.bkrepo.repository.pojo.node.NodeDetail
 import com.tencent.bkrepo.repository.pojo.repo.RepositoryDetail
 import jakarta.servlet.http.HttpServletRequest
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.util.unit.DataSize
 import org.springframework.web.servlet.HandlerMapping
@@ -66,7 +71,8 @@ class ArtifactContextHolder(
     compositeRepository: CompositeRepository,
     proxyRepository: ProxyRepository,
     artifactClient: ArtifactClient,
-    httpAuthSecurity: ObjectProvider<HttpAuthSecurity>
+    httpAuthSecurity: ObjectProvider<HttpAuthSecurity>,
+    nodeForwardService: ObjectProvider<NodeForwardService>,
 ) {
 
     init {
@@ -75,6 +81,7 @@ class ArtifactContextHolder(
         Companion.proxyRepository = proxyRepository
         Companion.artifactClient = artifactClient
         Companion.httpAuthSecurity = httpAuthSecurity
+        Companion.nodeForwardService = nodeForwardService
         require(artifactConfigurers.isNotEmpty()) { "No ArtifactConfigurer found!" }
         artifactConfigurers.forEach {
             artifactConfigurerMap[it.getRepositoryType()] = it
@@ -82,11 +89,13 @@ class ArtifactContextHolder(
     }
 
     companion object {
+        private val logger = LoggerFactory.getLogger(ArtifactContextHolder::class.java)
         private lateinit var artifactConfigurers: List<ArtifactConfigurer>
         private lateinit var compositeRepository: CompositeRepository
         private lateinit var proxyRepository: ProxyRepository
         private lateinit var artifactClient: ArtifactClient
         private lateinit var httpAuthSecurity: ObjectProvider<HttpAuthSecurity>
+        private lateinit var nodeForwardService: ObjectProvider<NodeForwardService>
 
 
         private const val RECEIVE_RATE_LIMIT_OF_REPO = "receiveRateLimit"
@@ -283,6 +292,34 @@ class ArtifactContextHolder(
             )
             nodeDetail?.let { request.setAttribute(attrKey, nodeDetail) }
             return nodeDetail
+        }
+
+        /**
+         * 判断是否需要forward
+         *
+         * @param node 待下载node
+         * @param storageCredentials 待下载node所在存储
+         * @param userId 正在下载的用户id
+         *
+         * @return 不需要forward时返回null，需要时候返回forward node与其所在存储
+         */
+        fun getForwardNodeDetail(
+            node: NodeDetail,
+            storageCredentials: StorageCredentials?,
+            userId: String = SecurityUtils.getUserId(),
+        ): Pair<NodeDetail, StorageCredentials?>? {
+            val forwardNode: NodeDetail = nodeForwardService.ifAvailable?.forward(node, userId) ?: return null
+            logger.info("Load[${node.identity()}] forward to [${forwardNode.identity()}].")
+            ActionAuditContext.current().addExtendData("alphaApkSha256", forwardNode.sha256)
+            ActionAuditContext.current().addExtendData("alphaApkMd5", forwardNode.md5)
+            val forwardNodeStorageCredentials = if (forwardNode.repoName == node.repoName) {
+                storageCredentials
+            } else {
+                val repo = getRepoDetail(RepositoryId(forwardNode.projectId, forwardNode.repoName))
+                logger.info("use forward node storage credentials[${repo.storageCredentials?.key}]")
+                repo.storageCredentials
+            }
+            return Pair(forwardNode, forwardNodeStorageCredentials)
         }
 
         /**

--- a/src/backend/common/common-artifact/artifact-service/src/main/kotlin/com/tencent/bkrepo/common/artifact/repository/local/LocalRepository.kt
+++ b/src/backend/common/common-artifact/artifact-service/src/main/kotlin/com/tencent/bkrepo/common/artifact/repository/local/LocalRepository.kt
@@ -56,11 +56,14 @@ abstract class LocalRepository : AbstractArtifactRepository() {
 
     override fun onDownload(context: ArtifactDownloadContext): ArtifactResource? {
         with(context) {
-            val node = ArtifactContextHolder.getNodeDetail(artifactInfo)
-            node?.let { downloadIntercept(context, it) }
-            val inputStream = storageManager.loadArtifactInputStream(node, storageCredentials) ?: return null
+            val node = ArtifactContextHolder.getNodeDetail(artifactInfo) ?: return null
+            downloadIntercept(context, node)
+
+            val (load, loadStorage) = ArtifactContextHolder.getForwardNodeDetail(node, storageCredentials, userId)
+                ?: Pair(node, storageCredentials)
+            val inputStream = storageManager.loadArtifactInputStream(load, loadStorage) ?: return null
             val responseName = artifactInfo.getResponseName()
-            return ArtifactResource(inputStream, responseName, node, ArtifactChannel.LOCAL, useDisposition)
+            return ArtifactResource(inputStream, responseName, load, ArtifactChannel.LOCAL, useDisposition)
         }
     }
 

--- a/src/backend/core/generic/biz-generic/src/main/kotlin/com/tencent/bkrepo/generic/artifact/GenericLocalRepository.kt
+++ b/src/backend/core/generic/biz-generic/src/main/kotlin/com/tencent/bkrepo/generic/artifact/GenericLocalRepository.kt
@@ -513,10 +513,12 @@ class GenericLocalRepository(
                 return downloadFolder(this, node)
             }
             downloadIntercept(this, node)
-            val inputStream = storageManager.loadArtifactInputStream(node, storageCredentials) ?: return null
-            val responseName = artifactInfo.getResponseName()
 
-            return ArtifactResource(inputStream, responseName, node, ArtifactChannel.LOCAL, useDisposition)
+            val (load, loadStorage) = ArtifactContextHolder.getForwardNodeDetail(node, storageCredentials, userId)
+                ?: Pair(node, storageCredentials)
+            val inputStream = storageManager.loadArtifactInputStream(load, loadStorage) ?: return null
+            val responseName = artifactInfo.getResponseName()
+            return ArtifactResource(inputStream, responseName, load, ArtifactChannel.LOCAL, useDisposition)
         }
     }
 

--- a/src/backend/replication/biz-replication/src/test/kotlin/com/tencent/bkrepo/replication/fdtp/FdtpAFTTest.kt
+++ b/src/backend/replication/biz-replication/src/test/kotlin/com/tencent/bkrepo/replication/fdtp/FdtpAFTTest.kt
@@ -29,6 +29,7 @@ package com.tencent.bkrepo.replication.fdtp
 
 import com.tencent.bkrepo.common.artifact.config.ArtifactConfigurer
 import com.tencent.bkrepo.common.artifact.hash.sha256
+import com.tencent.bkrepo.common.artifact.manager.NodeForwardService
 import com.tencent.bkrepo.common.artifact.metrics.ARTIFACT_UPLOADING_TIME
 import com.tencent.bkrepo.common.artifact.metrics.ArtifactMetrics
 import com.tencent.bkrepo.common.artifact.repository.composite.CompositeRepository
@@ -61,6 +62,7 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.mockito.Mockito
+import org.springframework.beans.factory.ObjectProvider
 import org.springframework.cloud.loadbalancer.support.SimpleObjectProvider
 import java.io.ByteArrayInputStream
 import java.util.concurrent.ConcurrentHashMap
@@ -104,6 +106,7 @@ class FdtpAFTTest {
             proxyRepository,
             artifactClient,
             httpAuthSecurity,
+            Mockito.mock(ObjectProvider::class.java) as ObjectProvider<NodeForwardService>
         )
         val helper = StorageHealthMonitorHelper(ConcurrentHashMap())
         ArtifactFileFactory(StorageProperties(), helper, limitCheckService)


### PR DESCRIPTION
1. #3469 

考虑forward操作与业务强相关，且repository层中会根据node设置相关响应数据，因此将forward操作移至repository层