### PR TITLE
fix: ci模式下，切换项目没校验项目权限 #3894

### DIFF
--- a/src/frontend/core/devops-repository/src/AppMixin.js
+++ b/src/frontend/core/devops-repository/src/AppMixin.js
@@ -3,15 +3,12 @@ import ConfirmDialog from '@repository/components/ConfirmDialog'
 import GlobalUploadViewport from '@repository/components/GlobalUploadViewport'
 import { routeBase } from '@repository/utils'
 import Vue from 'vue'
-import { mapActions, mapMutations, mapState } from 'vuex'
+import { mapMutations, mapState } from 'vuex'
 export default {
     name: 'App',
     components: { ConfirmDialog, GlobalUploadViewport },
     computed: {
         ...mapState(['userInfo', 'projectList']),
-        ...mapActions([
-            'checkPM'
-        ]),
         projectId () {
             return this.$route.params.projectId
         }
@@ -61,7 +58,6 @@ export default {
                 window.globalVue.$on('change::$currentProjectId', data => { // 蓝鲸Devops选择项目时切换
                     localStorage.setItem('projectId', data.currentProjectId)
                     if (this.projectId !== data.currentProjectId) {
-                        this.checkPM({ projectId: data.currentProjectId })
                         this.goHome(data.currentProjectId)
                     }
                 })

--- a/src/frontend/core/devops-repository/src/views/index.vue
+++ b/src/frontend/core/devops-repository/src/views/index.vue
@@ -92,7 +92,8 @@
             }
         },
         mounted () {
-            this.checkPM({ projectId: this.$route.params.projectId })
+            const projectId = this.$route.params.projectId ? this.$route.params.projectId : localStorage.getItem('projectId')
+            this.checkPM({ projectId: projectId })
         },
         methods: {
             ...mapActions([

--- a/src/frontend/core/devops-repository/src/views/repoList/index.vue
+++ b/src/frontend/core/devops-repository/src/views/repoList/index.vue
@@ -114,7 +114,8 @@
     import createRepoDialog from '@repository/views/repoList/createRepoDialog'
     import iamDenyDialog from '@repository/components/IamDenyDialog/IamDenyDialog'
     import { mapState, mapActions } from 'vuex'
-    import {ciDisableRepoEnum, repoEnum} from '@repository/store/publicEnum'
+    import { ciDisableRepoEnum, repoEnum } from '@repository/store/publicEnum'
+    import { subEnv } from '@blueking/sub-saas'
     import { formatDate, convertFileSize, debounce } from '@repository/utils'
     import { cloneDeep } from 'lodash'
     import genericCleanDialog from '@repository/views/repoGeneric/genericCleanDialog'
@@ -155,6 +156,9 @@
             ...mapState(['userList', 'userInfo']),
             projectId () {
                 return this.$route.params.projectId
+            },
+            isSubSaas () {
+                return subEnv
             }
         },
         watch: {
@@ -185,7 +189,8 @@
                 'deleteRepoList',
                 'getRepoListWithoutPage',
                 'getPermissionUrl',
-                'getProjectMetrics'
+                'getProjectMetrics',
+                'checkPM'
             ]),
             disCheck (repoName) {
                 if (MODE_CONFIG !== 'ci') {
@@ -206,6 +211,9 @@
             },
             getListData () {
                 this.isLoading = true
+                if (!this.isSubSaas && this.MODE_CONFIG === 'ci') {
+                    this.checkPM({ projectId: this.projectId })
+                }
                 this.getRepoListWithoutPage({
                     projectId: this.projectId,
                     ...this.query


### PR DESCRIPTION
由蓝盾进入制品库或者刷新，调用会触发index下面的mounted方法，但是由于未知原因，导致触发的时候未取得projectId，致使权限未取得，修改获取到router.param未定义的时候，取localstorage，此参数再触发跳转前已经设置了。ci模式下，切换项目的时候如果未触及刷新调用，不会调用checkPM方法，触发项目变化一定会跳转到repository的路由，故修改到repository的创建时，再次校验权限。