### PR TITLE
feat: 仅在通过质量规则时主动解禁制品 #3971

### DIFF
--- a/src/backend/analyst/biz-analyst/src/main/kotlin/com/tencent/bkrepo/analyst/service/impl/ScanQualityServiceImpl.kt
+++ b/src/backend/analyst/biz-analyst/src/main/kotlin/com/tencent/bkrepo/analyst/service/impl/ScanQualityServiceImpl.kt
@@ -27,6 +27,8 @@
 
 package com.tencent.bkrepo.analyst.service.impl
 
+import com.google.common.cache.CacheBuilder
+import com.google.common.cache.CacheLoader
 import com.tencent.bkrepo.analyst.component.ScannerPermissionCheckHandler
 import com.tencent.bkrepo.analyst.dao.PlanArtifactLatestSubScanTaskDao
 import com.tencent.bkrepo.analyst.dao.ScanPlanDao
@@ -52,6 +54,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Lazy
 import org.springframework.stereotype.Service
+import java.util.concurrent.TimeUnit
 
 @Service
 class ScanQualityServiceImpl(
@@ -63,6 +66,12 @@ class ScanQualityServiceImpl(
     @Autowired
     @Lazy
     private lateinit var permissionCheckHandler: ScannerPermissionCheckHandler
+
+    private val scannerCache = CacheBuilder.newBuilder()
+        .maximumSize(1000)
+        .refreshAfterWrite(2L, TimeUnit.MINUTES)
+        .expireAfterWrite(3L, TimeUnit.MINUTES)
+        .build(CacheLoader.from<String, Scanner> { scannerService.get(it) })
 
     override fun getScanQuality(planId: String): ScanQuality {
         val scanPlan = scanPlanDao.get(planId)
@@ -132,13 +141,21 @@ class ScanQualityServiceImpl(
         repoType: String,
         fullPath: String
     ): Boolean {
-        return shouldForbidBeforeScanned(projectId, repoName, repoType) { rule ->
-            val matched = RuleUtil.match(rule, projectId, repoName, fullPath)
-            if (matched) {
-                logger.info("Artifact[$projectId/$repoName$fullPath] should be forbidden before scanned")
+        return shouldForbidBeforeScanned(
+            projectId, repoName, repoType,
+            ruleMatcher = { rule ->
+                val matched = RuleUtil.match(rule, projectId, repoName, fullPath)
+                if (matched) {
+                    logger.info("Artifact[$projectId/$repoName$fullPath] should be forbidden before scanned")
+                }
+                matched
+            },
+            fileNameExtMatcher = { scanner ->
+                val fileNameExtension = fullPath.substringAfterLast('.', "")
+                val supportFileNameExt = scannerCache.get(scanner).supportFileNameExt
+                supportFileNameExt.isEmpty() || fileNameExtension in supportFileNameExt
             }
-            matched
-        }
+        )
     }
 
     override fun shouldForbidBeforeScanned(
@@ -148,7 +165,7 @@ class ScanQualityServiceImpl(
         packageName: String,
         packageVersion: String
     ): Boolean {
-        return shouldForbidBeforeScanned(projectId, repoName, repoType) { rule ->
+        return shouldForbidBeforeScanned(projectId, repoName, repoType, ruleMatcher = { rule ->
             val matched = RuleUtil.match(rule, projectId, repoName, repoType, packageName, packageVersion)
             if (matched) {
                 logger.info(
@@ -156,20 +173,21 @@ class ScanQualityServiceImpl(
                 )
             }
             matched
-        }
+        })
     }
 
     private fun shouldForbidBeforeScanned(
         projectId: String,
         repoName: String,
         repoType: String,
-        ruleMatcher: (rule: Rule) -> Boolean
+        ruleMatcher: (rule: Rule) -> Boolean,
+        fileNameExtMatcher: (scanner: String) -> Boolean = { true },
     ): Boolean {
         return scanPlanDao
             .findByProjectIdAndRepoName(projectId, repoName, repoType, true)
             .any {
                 val forbidNotScanned = it.scanQuality[ScanQuality::forbidNotScanned.name] == true
-                val forbid = forbidNotScanned && ruleMatcher(it.rule.readJsonString())
+                val forbid = forbidNotScanned && ruleMatcher(it.rule.readJsonString()) && fileNameExtMatcher(it.scanner)
                 if (forbid) {
                     logger.info("forbid before scanned by plan[${it.id}]")
                 }

--- a/src/backend/analyst/biz-analyst/src/main/kotlin/com/tencent/bkrepo/analyst/service/impl/ScanQualityServiceImpl.kt
+++ b/src/backend/analyst/biz-analyst/src/main/kotlin/com/tencent/bkrepo/analyst/service/impl/ScanQualityServiceImpl.kt
@@ -219,28 +219,40 @@ class ScanQualityServiceImpl(
             }
         }
 
-        // 扫描过时判断是否通过质量规则
-        val forbidQualityUnPass = plan.scanQuality[ScanQuality::forbidQualityUnPass.name] == true
-        if (!forbidQualityUnPass) {
-            return CheckForbidResult(shouldUnforbid = true)
-        }
-
         if (planSubtask.status != SubScanTaskStatus.SUCCESS.name) {
             // 扫描失败时不禁用也不解禁
             return CheckForbidResult()
         }
 
+        // 未配置质量规则时解禁
+        if (!hasQualityRule(plan.scanQuality)) {
+            return CheckForbidResult(shouldUnforbid = true)
+        }
+
         val scanner = scannerService.get(plan.scanner)
         val scanResultOverview = planSubtask.scanResultOverview ?: emptyMap()
-        val shouldForbid = !checkScanQualityRedLine(plan.scanQuality, scanResultOverview, scanner)
-        var type = ForbidType.NONE
-        if (shouldForbid) {
-            type = ForbidType.QUALITY_UNPASS
-            logger.info("forbid [$projectId/$repoName$fullPath][$sha256][${plan.id}], reason: exceed red line")
+        val qualityPass = checkScanQualityRedLine(plan.scanQuality, scanResultOverview, scanner)
+
+        return if (qualityPass) {
+            // 质量规则通过时解禁
+            CheckForbidResult(shouldUnforbid = true)
+        } else {
+            val forbidQualityUnPass = plan.scanQuality[ScanQuality::forbidQualityUnPass.name] == true
+            if (forbidQualityUnPass) {
+                // 质量规则未通过且开启了自动禁用，则禁用
+                logger.info("forbid [$projectId/$repoName$fullPath][$sha256][${plan.id}], reason: exceed red line")
+                CheckForbidResult(true, ForbidType.QUALITY_UNPASS.name, ScanPlanConverter.convert(plan))
+            } else {
+                // 质量规则未通过但未开启自动禁用，维持现状
+                CheckForbidResult()
+            }
         }
-        return CheckForbidResult(
-            shouldForbid, type.name, ScanPlanConverter.convert(plan), !shouldForbid
-        )
+    }
+
+    private fun hasQualityRule(scanQuality: Map<String, Any>): Boolean {
+        return CveOverviewKey.entries.any { overviewKey ->
+            scanQuality[overviewKey.level.levelName] != null
+        }
     }
 
     companion object {

--- a/src/backend/analyst/biz-analyst/src/main/kotlin/com/tencent/bkrepo/analyst/statemachine/subtask/action/FinishSubtaskAction.kt
+++ b/src/backend/analyst/biz-analyst/src/main/kotlin/com/tencent/bkrepo/analyst/statemachine/subtask/action/FinishSubtaskAction.kt
@@ -172,7 +172,11 @@ class FinishSubtaskAction(
 
         // 质量规则检查结果
         val planId = subTask.planId
-        val qualityPass = if (subTask.scanQuality.isNullOrEmpty() || planId == null) {
+        val qualityPass = if (
+            subTask.scanQuality.isNullOrEmpty() ||
+            planId == null ||
+            resultSubTaskStatus != SubScanTaskStatus.SUCCESS.name
+        ) {
             null
         } else {
             overview.isEmpty() || scanQualityService.checkScanQualityRedLine(planId, overview as Map<String, Number>)


### PR DESCRIPTION
1. #3971
2. 扫描失败时不设置`qualityRedLine`元数据
3. 对于扫描器不支持的文件类型，制品入库时不自动禁用