### PR TITLE
feat: 支持 HuggingFace 仓库的 Kubernetes 容器化部署 #4235

### DIFF
--- a/support-files/kubernetes/charts/bkrepo/README.md
+++ b/support-files/kubernetes/charts/bkrepo/README.md
@@ -62,6 +62,7 @@ $ helm uninstall bkrepo
 - npm
 - pypi
 - helm
+- huggingface
 
 |参数|描述|默认值 |
 |---|---|---|
@@ -251,6 +252,15 @@ $ helm uninstall bkrepo
 |---|---|---|
 | `helm.enabled` | 是否部署helm | `false` |
 | `helm.config`  | helm配置 | `{}` |
+
+### huggingface registry服务配置
+
+**以下为除Kubernetes组件通用配置之外的配置列表**
+
+|参数|描述|默认值 |
+|---|---|---|
+| `huggingface.enabled` | 是否部署huggingface | `false` |
+| `huggingface.config.domain` | huggingface domain地址 | `${gateway.host}/huggingface` |
 
 
 您可以通过`--set key=value[,key=value]`来指定参数进行安装。例如，

--- a/support-files/kubernetes/charts/bkrepo/questions.yaml
+++ b/support-files/kubernetes/charts/bkrepo/questions.yaml
@@ -101,3 +101,8 @@ questions:
     type: boolean
     default: false
     group: "registry服务部署选择"
+  - variable: huggingface.enabled
+    label: "是否部署huggingface registry"
+    type: boolean
+    default: false
+    group: "registry服务部署选择"

--- a/support-files/kubernetes/charts/bkrepo/templates/huggingface/configmap.yaml
+++ b/support-files/kubernetes/charts/bkrepo/templates/huggingface/configmap.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.huggingface.enabled -}}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ include "common.names.fullname" . }}-huggingface
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: huggingface
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  {{- end }}
+data:
+  application.yml: |-
+    {{- if keys $.Values.huggingface.config }}
+    {{- toYaml .Values.huggingface.config | nindent 4 }}
+    {{- end}}
+    huggingface:
+      {{- if or .Values.ingress.tls .Values.forceHttps }}
+      domain: https://{{ .Values.gateway.host }}/huggingface
+      {{- else }}
+      domain: http://{{ .Values.gateway.host }}/huggingface
+      {{- end }}
+{{- end }}

--- a/support-files/kubernetes/charts/bkrepo/templates/huggingface/deployment.yaml
+++ b/support-files/kubernetes/charts/bkrepo/templates/huggingface/deployment.yaml
@@ -1,0 +1,121 @@
+{{- if .Values.huggingface.enabled -}}
+apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
+kind: Deployment
+metadata:
+  name: {{ include "common.names.fullname" . }}-huggingface
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: huggingface
+    {{ include "bkrepo.labelValues.scope" . }}: {{ include "bkrepo.labelValues.scope.backend" . }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: huggingface
+  replicas: {{ default 1 .Values.huggingface.replicaCount }}
+  template:
+    metadata:
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
+        app.kubernetes.io/component: huggingface
+        {{ include "bkrepo.labelValues.scope" . }}: {{ include "bkrepo.labelValues.scope.backend" . }}
+        {{- if .Values.huggingface.podLabels }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.huggingface.podLabels "context" $) | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ template "bkrepo.serviceAccountName" . }}
+      {{- include "bkrepo.imagePullSecrets" . | nindent 6 }}
+      {{- if .Values.huggingface.hostAliases }}
+      hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.huggingface.hostAliases "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.huggingface.affinity }}
+      affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.huggingface.affinity "context" $) | nindent 8 }}
+      {{- else }}
+      affinity:
+        {{- if eq .Values.persistence.accessMode "ReadWriteOnce" }}
+        podAffinity: {{- include "common.affinities.pods" (dict "type" "soft" "component" "repository" "context" $) | nindent 10 }}
+        {{- else }}
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.repository.podAffinityPreset "component" "huggingface" "context" $) | nindent 10 }}
+        {{- end }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.huggingface.podAntiAffinityPreset "component" "huggingface" "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.huggingface.nodeAffinityPreset.type "key" .Values.huggingface.nodeAffinityPreset.key "values" .Values.huggingface.nodeAffinityPreset.values) | nindent 10 }}
+      {{- end }}
+      {{- if .Values.huggingface.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.huggingface.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.huggingface.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.huggingface.tolerations "context" .) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.huggingface.priorityClassName }}
+      priorityClassName: {{ .Values.huggingface.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.huggingface.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.huggingface.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: huggingface
+          image: {{ include "bkrepo.images.image" ( dict "imageRoot" .Values.huggingface.image "global" .Values.global "bkrepo" .Values.common) }}
+          imagePullPolicy: {{ .Values.huggingface.image.pullPolicy }}
+          {{- if .Values.huggingface.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.huggingface.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.huggingface.resources }}
+          resources: {{- toYaml .Values.huggingface.resources | nindent 12 }}
+          {{- end }}
+          env:
+            - name: BK_REPO_JVM_OPTION
+              value: {{ .Values.common.jvmOption }}
+            - name: BK_REPO_PROFILE
+              value: {{ .Values.common.springProfile }}
+            - name: BK_REPO_SERVICE_PREFIX
+              value: {{ include "common.names.fullname" . }}-
+          ports:
+            - name: http
+              containerPort: 25823
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/livenessState
+              port: http
+            initialDelaySeconds: 120
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 5
+            successThreshold: 1
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readinessState
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 5
+            successThreshold: 1
+          volumeMounts:
+            - name: storage
+              mountPath: {{ .Values.common.mountPath }}
+            {{- if .Values.tls.mongodb.enabled  }}
+            - name: mongodb-ca
+              mountPath: /data/certs/mongodb
+              readOnly: true
+            {{- end }}
+      volumes:
+        - name: storage
+          {{- if .Values.common.config.storage.nfs.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "common.names.fullname" . }}-nfs-pvc
+          {{- else if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ template "common.names.fullname" . }}-storage{{- end }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- if .Values.tls.mongodb.enabled }}
+        - name: mongodb-ca
+          secret:
+            secretName: {{ .Values.tls.mongodb.existingSecret }}
+        {{- end }}
+{{- end }}

--- a/support-files/kubernetes/charts/bkrepo/templates/huggingface/service.yaml
+++ b/support-files/kubernetes/charts/bkrepo/templates/huggingface/service.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.huggingface.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "common.names.fullname" . }}-huggingface
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: huggingface
+    {{ include "bkrepo.labelValues.scope" . }}: {{ include "bkrepo.labelValues.scope.backend" . }}
+    {{- if .Values.commonLabels }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP
+  selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
+    app.kubernetes.io/component: huggingface
+{{- end }}

--- a/support-files/kubernetes/charts/bkrepo/values.schema.json
+++ b/support-files/kubernetes/charts/bkrepo/values.schema.json
@@ -189,6 +189,16 @@
                     "form": true
                 }
             }
+        },
+        "huggingface": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "title": "是否部署huggingface registry",
+                    "form": true
+                }
+            }
         }
     }
 }

--- a/support-files/kubernetes/charts/bkrepo/values.yaml
+++ b/support-files/kubernetes/charts/bkrepo/values.yaml
@@ -972,6 +972,46 @@ helm:
   podLabels: {}
   podAnnotations: {}
   priorityClassName: ""
+
+## huggingface registry服务配置
+huggingface:
+  enabled: false
+  config: {}
+  ## Kubernetes 通用配置
+  image:
+    registry: registry.hub.docker.com
+    repository: bkrepo/bkrepo-huggingface
+    tag: 1.1.0
+    pullPolicy: IfNotPresent
+    pullSecrets: []
+  replicaCount: 1
+  hostAliases: []
+  resources:
+    requests:
+      cpu: 100m
+      memory: 1000Mi
+    limits:
+      cpu: 500m
+      memory: 1500Mi
+  containerSecurityContext:
+    enabled: false
+    runAsUser: 1001
+    runAsNonRoot: true
+  podSecurityContext:
+    enabled: false
+    fsGroup: 1001
+  podAffinityPreset: ""
+  podAntiAffinityPreset: ""
+  nodeAffinityPreset:
+    type: ""
+    key: ""
+    values: []
+  affinity: {}
+  nodeSelector: {}
+  tolerations: []
+  podLabels: {}
+  podAnnotations: {}
+  priorityClassName: ""
 ## job registry服务配置
 job:
   enabled: true


### PR DESCRIPTION
## Summary
- 补齐 HuggingFace registry 的 Helm values、schema 和安装问题配置。
- 新增 HuggingFace ConfigMap、Deployment、Service，复用现有 registry 服务部署模式。
- 更新 chart README，说明 HuggingFace 开关和域名配置。

## Test plan
- [x] Python JSON/YAML syntax validation for `values.schema.json`, `values.yaml`, and `questions.yaml`
- [x] `helm template` with `huggingface.enabled=false` verifies HuggingFace resources are not rendered
- [x] `helm template` with `huggingface.enabled=true` verifies HuggingFace resources, port `25823`, and domain render correctly
