### PR TITLE
feat: 支持认证服务校验文件服务登录签发的 Bearer Token

### DIFF
--- a/src/backend/auth/biz-auth/src/main/kotlin/com/tencent/bkrepo/auth/interceptor/AuthInterceptor.kt
+++ b/src/backend/auth/biz-auth/src/main/kotlin/com/tencent/bkrepo/auth/interceptor/AuthInterceptor.kt
@@ -68,7 +68,6 @@ import com.tencent.bkrepo.common.security.util.JwtUtils
 import com.tencent.bkrepo.common.service.util.HttpSigner
 import com.tencent.bkrepo.common.service.util.SpringContextUtils
 import com.tencent.bkrepo.repository.constant.SYSTEM_USER
-import io.jsonwebtoken.JwtException
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.apache.commons.codec.digest.HmacAlgorithms
@@ -134,7 +133,7 @@ class AuthInterceptor(
         val token = authHeader.removePrefix(BEARER_AUTH_PREFIX)
         val userId = parseInternalJwtUserId(token)
         if (userId != null) {
-            return checkInternalJwtToken(request, userId)
+            return checkUserFromJwt(request, userId)
         }
         return checkOauthToken(request, authHeader)
     }
@@ -142,19 +141,19 @@ class AuthInterceptor(
     private fun parseInternalJwtUserId(token: String): String? {
         return try {
             JwtUtils.validateToken(signingKey, token).body.subject?.takeIf { it.isNotBlank() }
-        } catch (e: JwtException) {
-            logger.debug("validate internal jwt token failed", e)
-            null
-        } catch (e: IllegalArgumentException) {
+        } catch (e: Exception) {
             logger.debug("validate internal jwt token failed", e)
             null
         }
     }
 
-    private fun checkInternalJwtToken(request: HttpServletRequest, userId: String): Boolean {
+    private fun checkUserFromJwt(request: HttpServletRequest, userId: String): Boolean {
         val userAccess = userAccessApiSet.any { request.requestURI.contains(it) }
-        val user = userService.getUserInfoById(userId)
-        val isAdmin = user?.admin ?: false
+        val user = userService.getUserInfoById(userId) ?: run {
+            logger.warn("internal jwt user [$userId] not found")
+            throw IllegalArgumentException("internal jwt user not found")
+        }
+        val isAdmin = user.admin
         request.setAttribute(USER_KEY, userId)
         request.setAttribute(ADMIN_USER, isAdmin)
         if (!isAdmin && !userAccess) {

--- a/src/backend/auth/biz-auth/src/main/kotlin/com/tencent/bkrepo/auth/interceptor/AuthInterceptor.kt
+++ b/src/backend/auth/biz-auth/src/main/kotlin/com/tencent/bkrepo/auth/interceptor/AuthInterceptor.kt
@@ -63,9 +63,12 @@ import com.tencent.bkrepo.common.api.constant.USER_KEY
 import com.tencent.bkrepo.common.security.exception.AuthenticationException
 import com.tencent.bkrepo.common.security.exception.PermissionException
 import com.tencent.bkrepo.common.security.http.core.HttpAuthSecurity
+import com.tencent.bkrepo.common.security.http.jwt.JwtAuthProperties
+import com.tencent.bkrepo.common.security.util.JwtUtils
 import com.tencent.bkrepo.common.service.util.HttpSigner
 import com.tencent.bkrepo.common.service.util.SpringContextUtils
 import com.tencent.bkrepo.repository.constant.SYSTEM_USER
+import io.jsonwebtoken.JwtException
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.apache.commons.codec.digest.HmacAlgorithms
@@ -84,6 +87,10 @@ class AuthInterceptor(
 
     private val oauthAuthorizationService: OauthAuthorizationService by lazy { SpringContextUtils.getBean() }
 
+    private val jwtProperties: JwtAuthProperties by lazy { SpringContextUtils.getBean() }
+
+    private val signingKey by lazy { JwtUtils.createSigningKey(jwtProperties.secretKey) }
+
     override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
         val authHeader = request.getHeader(AUTHORIZATION).orEmpty()
         var authFailStr = String.format(AUTH_FAILED_RESPONSE, "empty auth header")
@@ -101,8 +108,8 @@ class AuthInterceptor(
 
             // oauth认证
             if (authHeader.startsWith(BEARER_AUTH_PREFIX)) {
-                authFailStr = String.format(AUTH_FAILED_RESPONSE, "illegal oauth token")
-                return checkOauthToken(request, authHeader)
+                authFailStr = String.format(AUTH_FAILED_RESPONSE, "illegal bearer token")
+                return checkBearerToken(request, authHeader)
             }
 
             // sign认证
@@ -121,6 +128,40 @@ class AuthInterceptor(
             logger.warn("check exception [$e]")
             return false
         }
+    }
+
+    private fun checkBearerToken(request: HttpServletRequest, authHeader: String): Boolean {
+        val token = authHeader.removePrefix(BEARER_AUTH_PREFIX)
+        val userId = parseInternalJwtUserId(token)
+        if (userId != null) {
+            return checkInternalJwtToken(request, userId)
+        }
+        return checkOauthToken(request, authHeader)
+    }
+
+    private fun parseInternalJwtUserId(token: String): String? {
+        return try {
+            JwtUtils.validateToken(signingKey, token).body.subject?.takeIf { it.isNotBlank() }
+        } catch (e: JwtException) {
+            logger.debug("validate internal jwt token failed", e)
+            null
+        } catch (e: IllegalArgumentException) {
+            logger.debug("validate internal jwt token failed", e)
+            null
+        }
+    }
+
+    private fun checkInternalJwtToken(request: HttpServletRequest, userId: String): Boolean {
+        val userAccess = userAccessApiSet.any { request.requestURI.contains(it) }
+        val user = userService.getUserInfoById(userId)
+        val isAdmin = user?.admin ?: false
+        request.setAttribute(USER_KEY, userId)
+        request.setAttribute(ADMIN_USER, isAdmin)
+        if (!isAdmin && !userAccess) {
+            logger.warn("user [$userId] can not access this endpoint [${request.requestURI}]")
+            throw IllegalArgumentException("user has no permission")
+        }
+        return true
     }
 
     private fun checkUserFromBasic(request: HttpServletRequest, authHeader: String): Boolean {


### PR DESCRIPTION
## Summary
- 支持认证服务 Bearer 分支优先校验内部 JWT，失败后 fallback 到现有 OAuth token 校验。
- 内部 JWT 校验成功后要求 subject 对应用户存在，用户不存在时拒绝认证。
- 当前 PR 为 #4246 的阶段性 draft，后续继续补充 AuthInterceptor 测试和完整目标验证。

## Progress
- [x] 确认 `JwtUtils` 和 `JwtAuthProperties` 在 auth 模块可直接复用的导入路径和异常类型。
- [x] 在 `AuthInterceptor` 增加内部 JWT 优先、OAuth fallback 的 Bearer 校验流程。
- [x] 内部 JWT 校验成功后要求 subject 非空且用户存在，再设置普通用户上下文。
- [ ] 补充 AuthInterceptor 测试覆盖 OAuth 兼容、内部 JWT 成功和失败边界。
- [ ] 运行认证模块目标测试并记录结果。

## Test plan
- [x] `./gradlew.bat :auth:biz-auth:compileKotlin`
- [ ] AuthInterceptor 单元测试
- [ ] 完整目标测试

Refs #4246