### PR TITLE
fix: 按需加载 replication cluster/list 避免无关页面请求 #4361

### DIFF
--- a/src/frontend/core/devops-repository/src/App.vue
+++ b/src/frontend/core/devops-repository/src/App.vue
@@ -48,9 +48,8 @@
             if (!this.isSubSaas && this.ciMode) {
                 this.loadDevopsUtils(window.BK_STATIC_URL + '/devops-utils.js')
                 // 请求管理员信息
-                this.ajaxUserInfo().then((userInfo) => {
+                this.ajaxUserInfo().then(() => {
                     this.$store.commit('SET_CREATING', false)
-                    userInfo.admin && this.getClusterList()
                 })
             } else {
                 let urlProjectId = ''
@@ -122,7 +121,6 @@
                             }
                         })
                     }
-                    userInfo.admin && this.getClusterList()
                 })
             }
         },
@@ -131,7 +129,6 @@
                 'getProjectList',
                 'ajaxUserInfo',
                 'getRepoUserList',
-                'getClusterList',
                 'getPermissionDialogConfig'
             ])
         }

--- a/src/frontend/core/devops-repository/src/views/planManage/logDetail.vue
+++ b/src/frontend/core/devops-repository/src/views/planManage/logDetail.vue
@@ -116,7 +116,8 @@
                 ]
             }
         },
-        created () {
+        async created () {
+            await this.getClusterList()
             this.handlerPaginationChange()
             this.getPlanLogDetail({
                 id: this.logId
@@ -135,7 +136,7 @@
         },
         methods: {
             formatDate,
-            ...mapActions(['getPlanLogDetail', 'getPlanLogPackageList']),
+            ...mapActions(['getClusterList', 'getPlanLogDetail', 'getPlanLogPackageList']),
             handlerPaginationChange ({ current = 1, limit = this.pagination.limit } = {}) {
                 this.pagination.current = current
                 this.pagination.limit = limit


### PR DESCRIPTION
移除 App.vue 对管理员的全局 getClusterList 预加载，仅在节点管理、创建分发计划及分发日志详情页按需请求。