### PR TITLE
fix: 修复 artifactId 含 Maven 占位符时正则解析失败 #3266

### DIFF
--- a/src/backend/core/maven/api-maven/src/main/kotlin/com/tencent/bkrepo/maven/util/MavenStringUtils.kt
+++ b/src/backend/core/maven/api-maven/src/main/kotlin/com/tencent/bkrepo/maven/util/MavenStringUtils.kt
@@ -144,9 +144,9 @@ object MavenStringUtils {
         val newVersion = this.version.removeSuffix(SNAPSHOT_SUFFIX).replace("+", "\\+")
         var artifactNameRegex = String.format(
             ARTIFACT_FORMAT,
-            this.artifactId,
+            Pattern.quote(this.artifactId),
             newVersion,
-            this.packaging
+            Pattern.quote(this.packaging)
         )
         val matcher = Pattern.compile(artifactNameRegex).matcher(artifactName)
         if (matcher.matches()) {

--- a/src/backend/core/maven/api-maven/src/main/kotlin/com/tencent/bkrepo/maven/util/MavenStringUtils.kt
+++ b/src/backend/core/maven/api-maven/src/main/kotlin/com/tencent/bkrepo/maven/util/MavenStringUtils.kt
@@ -141,7 +141,7 @@ object MavenStringUtils {
     }
 
     fun MavenVersion.setVersion(artifactName: String) {
-        val newVersion = this.version.removeSuffix(SNAPSHOT_SUFFIX).replace("+", "\\+")
+        val newVersion = Pattern.quote(this.version.removeSuffix(SNAPSHOT_SUFFIX))
         var artifactNameRegex = String.format(
             ARTIFACT_FORMAT,
             Pattern.quote(this.artifactId),

--- a/src/backend/core/maven/biz-maven/src/test/kotlin/com/tencent/bkrepo/maven/util/MavenStringUtilsTest.kt
+++ b/src/backend/core/maven/biz-maven/src/test/kotlin/com/tencent/bkrepo/maven/util/MavenStringUtilsTest.kt
@@ -150,6 +150,24 @@ internal class MavenStringUtilsTest {
     }
 
     @Test
+    fun resolverNameWithPlaceholderArtifactId() {
+        val artifactId = "my-\${property}"
+        val jarName = "my-\${property}-1.0.pom"
+        val mavenVersion = MavenVersion(
+            artifactId = artifactId,
+            version = "1.0",
+            packaging = "pom"
+        )
+        mavenVersion.setVersion(jarName)
+        assertAll(
+            { Assertions.assertEquals(artifactId, mavenVersion.artifactId) },
+            { Assertions.assertEquals("1.0", mavenVersion.version) },
+            { Assertions.assertEquals(null, mavenVersion.classifier) },
+            { Assertions.assertEquals("pom", mavenVersion.packaging) }
+        )
+    }
+
+    @Test
     fun parseMavenFileNameTest() {
         var jarName = "my-app-4.0-20220110.065755-5-jar-with-dependencies.jar"
         var mavenVersion = parseMavenFileName(jarName)

--- a/src/backend/core/maven/biz-maven/src/test/kotlin/com/tencent/bkrepo/maven/util/MavenStringUtilsTest.kt
+++ b/src/backend/core/maven/biz-maven/src/test/kotlin/com/tencent/bkrepo/maven/util/MavenStringUtilsTest.kt
@@ -2,6 +2,7 @@ package com.tencent.bkrepo.maven.util
 
 import com.tencent.bkrepo.maven.pojo.MavenVersion
 import com.tencent.bkrepo.maven.util.MavenStringUtils.parseMavenFileName
+import com.tencent.bkrepo.maven.util.MavenStringUtils.resolverName
 import com.tencent.bkrepo.maven.util.MavenStringUtils.setVersion
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
@@ -151,18 +152,17 @@ internal class MavenStringUtilsTest {
 
     @Test
     fun resolverNameWithPlaceholderVersion() {
+        // MavenLocalRepository.getUniquePath:634
+        // name.resolverName(mavenArtifactInfo.artifactId, mavenArtifactInfo.versionId)
+        val name = "uedm-parent-\${revision}-SNAPSHOT.pom"
         val artifactId = "uedm-parent"
-        val version = "\${revision}-SNAPSHOT"
-        val pomName = "uedm-parent-\${revision}-SNAPSHOT.pom"
-        val mavenVersion = MavenVersion(
-            artifactId = artifactId,
-            version = version,
-            packaging = "pom"
-        )
-        mavenVersion.setVersion(pomName)
+        val versionId = "\${revision}-SNAPSHOT"
+        val mavenVersion = name.resolverName(artifactId, versionId)
         assertAll(
             { Assertions.assertEquals(artifactId, mavenVersion.artifactId) },
-            { Assertions.assertEquals(version, mavenVersion.version) },
+            { Assertions.assertEquals(versionId, mavenVersion.version) },
+            { Assertions.assertEquals(null, mavenVersion.timestamp) },
+            { Assertions.assertEquals(null, mavenVersion.buildNo) },
             { Assertions.assertEquals(null, mavenVersion.classifier) },
             { Assertions.assertEquals("pom", mavenVersion.packaging) }
         )

--- a/src/backend/core/maven/biz-maven/src/test/kotlin/com/tencent/bkrepo/maven/util/MavenStringUtilsTest.kt
+++ b/src/backend/core/maven/biz-maven/src/test/kotlin/com/tencent/bkrepo/maven/util/MavenStringUtilsTest.kt
@@ -150,6 +150,25 @@ internal class MavenStringUtilsTest {
     }
 
     @Test
+    fun resolverNameWithPlaceholderVersion() {
+        val artifactId = "uedm-parent"
+        val version = "\${revision}-SNAPSHOT"
+        val pomName = "uedm-parent-\${revision}-SNAPSHOT.pom"
+        val mavenVersion = MavenVersion(
+            artifactId = artifactId,
+            version = version,
+            packaging = "pom"
+        )
+        mavenVersion.setVersion(pomName)
+        assertAll(
+            { Assertions.assertEquals(artifactId, mavenVersion.artifactId) },
+            { Assertions.assertEquals(version, mavenVersion.version) },
+            { Assertions.assertEquals(null, mavenVersion.classifier) },
+            { Assertions.assertEquals("pom", mavenVersion.packaging) }
+        )
+    }
+
+    @Test
     fun resolverNameWithPlaceholderArtifactId() {
         val artifactId = "my-\${property}"
         val jarName = "my-\${property}-1.0.pom"


### PR DESCRIPTION
## Summary
- `MavenVersion.setVersion` 对 `artifactId`、`packaging` 使用 `Pattern.quote()` 转义，修复含 `${xxx}` 等 Maven 占位符时触发 `PatternSyntaxException` 的问题
- Fixes #3266

## Test plan
- [x] `./gradlew :core:maven:biz-maven:test --tests "com.tencent.bkrepo.maven.util.MavenStringUtilsTest"`
- [x] 新增 `resolverNameWithPlaceholderArtifactId` 覆盖占位符 artifactId 场景
