### PR TITLE
fix: OCI registry 删除 manifest 时同步清理 package/version 元数据 #4349

### DIFF
--- a/src/backend/core/oci/biz-oci/src/main/kotlin/com/tencent/bkrepo/oci/artifact/repository/OciRegistryLocalRepository.kt
+++ b/src/backend/core/oci/biz-oci/src/main/kotlin/com/tencent/bkrepo/oci/artifact/repository/OciRegistryLocalRepository.kt
@@ -502,19 +502,46 @@ class OciRegistryLocalRepository(
      * 版本不存在时 status code 404
      */
     override fun remove(context: ArtifactRemoveContext) {
-        with(context.artifactInfo) {
-            val fullPath = ociOperationService.getNodeFullPath(this as OciArtifactInfo)
+        val artifactInfo = context.artifactInfo as OciArtifactInfo
+        with(artifactInfo) {
+            val fullPath = ociOperationService.getNodeFullPath(this)
                 ?: throw OciFileNotFoundException(
                     OciMessageCode.OCI_FILE_NOT_FOUND, getArtifactFullPath(), getRepoIdentify()
                 )
-            nodeService.getNodeDetail(ArtifactInfo(projectId, repoName, fullPath))
+            // 提前获取节点详情，删除节点后无法再解析 version 元数据
+            val nodeDetail = nodeService.getNodeDetail(ArtifactInfo(projectId, repoName, fullPath))
                 ?: throw OciFileNotFoundException(
                     OciMessageCode.OCI_FILE_NOT_FOUND, getArtifactFullPath(), getRepoIdentify()
                 )
             logger.info("Ready to delete $fullPath in repo ${getRepoIdentify()}")
             val request = NodeDeleteRequest(projectId, repoName, fullPath, context.userId)
             nodeService.deleteNode(request)
+            // 删除 manifest 时同步清理对应的 package/version 元数据，避免版本列表残留
+            // 仅清理命中的单个 version（tag），其余 tag 不受影响
+            if (this is OciManifestArtifactInfo) {
+                val version = extractVersionFromMetadata(nodeDetail.metadata ?: emptyMap()) ?: this.reference
+                deleteManifestVersion(packageName, version)
+            }
             OciResponseUtils.buildDeleteResponse(context.response)
+        }
+    }
+
+    /**
+     * 同步清理 manifest 对应的 package/version 元数据
+     * 删除节点后调用，保证存储节点与平台版本列表状态一致
+     */
+    private fun deleteManifestVersion(packageName: String, version: String) {
+        val projectId = repositoryDetail.projectId
+        val repoName = repositoryDetail.name
+        val packageKey = PackageKeys.ofName(repositoryDetail.type, packageName)
+        packageService.findVersionByName(projectId, repoName, packageKey, version)?.let {
+            logger.info("Will delete package version [$packageKey/$version] metadata in repo [$projectId/$repoName]")
+            packageService.deleteVersion(projectId, repoName, packageKey, version)
+            // 若该 package 下已无版本，同步清理 package 元数据，避免残留空 package
+            if (packageService.listAllVersion(projectId, repoName, packageKey, VersionListOption()).isEmpty()) {
+                logger.info("Will delete empty package [$packageKey] in repo [$projectId/$repoName]")
+                packageService.deletePackage(projectId, repoName, packageKey)
+            }
         }
     }
 


### PR DESCRIPTION
## 问题描述

OCI registry 删除 manifest（`DELETE /v2/<package>/manifests/<tag|digest>`）时，`OciRegistryLocalRepository.remove` 仅调用 `nodeService.deleteNode` 删除存储节点，未同步清理 `package/version` 元数据，导致：

- 平台版本列表仍残留已被删除的版本；
- 再次删除同一 manifest 时报“版本不存在”。

## 修复方案

删除 manifest 节点后，从节点元数据（`IMAGE_VERSION` / `OLD_DOCKER_VERSION`，即 tag）解析出 version，调用 `packageService.deleteVersion` 同步清理对应的 `package/version` 元数据：

- 同时覆盖“按 tag 删除”与“docker/skopeo 按 digest 删除”两种场景（digest 删除会命中到对应 tag 的 manifest 节点）；
- 仅清理命中的单个 version，其余 tag 不受影响；
- 若该 package 已无任何版本，进一步清理 package 元数据，避免残留空 package；
- blob/layer 删除仍只删节点，不联动清理 version 元数据（与既有行为一致）。

## 验证建议

`docker push` 后通过 `DELETE /v2/<package>/manifests/<tag>` 删除，确认平台版本列表不再残留该版本；再次删除不再报错。

Closes #4349
