### PR TITLE
feat: LocalRepository和RemoteRepository统一接入下载重定向 #4411

### DIFF
--- a/src/backend/common/common-artifact/artifact-service/src/main/kotlin/com/tencent/bkrepo/common/artifact/repository/local/LocalRepository.kt
+++ b/src/backend/common/common-artifact/artifact-service/src/main/kotlin/com/tencent/bkrepo/common/artifact/repository/local/LocalRepository.kt
@@ -47,6 +47,33 @@ import com.tencent.bkrepo.repository.pojo.packages.PackageVersion
  */
 abstract class LocalRepository : AbstractArtifactRepository() {
 
+    /**
+     * 与 Generic 一致：直接交由 [DownloadRedirectManager.redirect]。
+     * URI≠存储路径的子类：先 [DownloadRedirectManager.mayRedirect]（禁止未开启时查库），
+     * 再 mapping，然后调 [redirectAfterPrepare]。
+     */
+    override fun onDownloadRedirect(context: ArtifactDownloadContext): Boolean {
+        return redirectManager.redirect(context)
+    }
+
+    /**
+     * remapper 在完成路径 mapping 后调用：shouldRedirect → 拦截 → redirect。
+     */
+    protected fun redirectAfterPrepare(context: ArtifactDownloadContext): Boolean {
+        if (!redirectManager.shouldRedirect(context)) {
+            return false
+        }
+        val node = ArtifactContextHolder.getNodeDetail(context.artifactInfo) ?: return false
+        downloadIntercept(context, node)
+        beforeRedirect(context, node)
+        return redirectManager.redirect(context)
+    }
+
+    /**
+     * 确认会重定向后、真正 302 前（协议头、非标准 package 拦截）。
+     */
+    protected open fun beforeRedirect(context: ArtifactDownloadContext, node: NodeDetail) = Unit
+
     override fun onUpload(context: ArtifactUploadContext) {
         with(context) {
             val nodeCreateRequest = buildNodeCreateRequest(this)

--- a/src/backend/common/common-artifact/artifact-service/src/main/kotlin/com/tencent/bkrepo/common/artifact/repository/redirect/CosRedirectService.kt
+++ b/src/backend/common/common-artifact/artifact-service/src/main/kotlin/com/tencent/bkrepo/common/artifact/repository/redirect/CosRedirectService.kt
@@ -64,6 +64,30 @@ class CosRedirectService(
     private val storageProperties: StorageProperties,
     private val storageService: StorageService,
 ) : DownloadRedirectService {
+
+    /**
+     * 配置门控（不查 node）。仅供 remapper 在路径解析前调用；判定结果不等价于 [doShouldRedirect]。
+     */
+    override fun mayRedirect(context: ArtifactDownloadContext): Boolean {
+        if (!storageProperties.redirect.enabled) {
+            return false
+        }
+        val storageCredentials = context.repositoryDetail.storageCredentials
+            ?: storageProperties.defaultStorageCredentials()
+        if (storageCredentials !is InnerCosCredentials) {
+            return false
+        }
+        if (!isProjectAllowed(context.projectId)) {
+            return false
+        }
+        val redirectSettings = DownloadRedirectSettings.from(context.repositoryDetail.configuration)
+        val repoSupportRedirectTo = redirectSettings?.redirectTo == RedirectTo.INNERCOS.name
+        val redirectTo = HttpContextHolder.getRequest().getHeader("X-BKREPO-DOWNLOAD-REDIRECT-TO")
+        return repoSupportRedirectTo ||
+            redirectTo == RedirectTo.INNERCOS.name ||
+            storageProperties.redirect.redirectAllDownload
+    }
+
     override fun doShouldRedirect(context: ArtifactDownloadContext): Boolean {
         if (!storageProperties.redirect.enabled) {
             return false
@@ -145,7 +169,8 @@ class CosRedirectService(
             ?: node.metadata[HttpHeaders.CACHE_CONTROL.lowercase(Locale.getDefault())]?.toString()
             ?: StringPool.NO_CACHE
         request.parameters["response-cache-control"] = cacheControl
-        val mime = determineMediaType(filename, storageProperties.response.mimeMappings)
+        val mime = context.getStringAttribute(ATTR_RESPONSE_CONTENT_TYPE)
+            ?: determineMediaType(filename, storageProperties.response.mimeMappings)
         request.parameters["response-content-type"] = mime
 
         if (context.useDisposition) {
@@ -177,5 +202,8 @@ class CosRedirectService(
 
     companion object {
         private val logger = LoggerFactory.getLogger(CosRedirectService::class.java)
+
+        /** 依赖源协议要求的 Content-Type（如 OCI mediaType），优先于按文件名推断 */
+        const val ATTR_RESPONSE_CONTENT_TYPE = "cos.redirect.responseContentType"
     }
 }

--- a/src/backend/common/common-artifact/artifact-service/src/main/kotlin/com/tencent/bkrepo/common/artifact/repository/redirect/DownloadRedirectManager.kt
+++ b/src/backend/common/common-artifact/artifact-service/src/main/kotlin/com/tencent/bkrepo/common/artifact/repository/redirect/DownloadRedirectManager.kt
@@ -36,13 +36,49 @@ class DownloadRedirectManager(
     private val redirectServices: List<DownloadRedirectService>
 ) {
     /**
-     * 重定向下载请求
-     *
-     * @param context 下载请求上下文
-     *
-     * @return true 已重定向请求， false 未重定向请求
+     * 配置层面是否可能重定向（不访问 node/DB）。
+     * 路径需要二次解析的仓：必须先调此方法，false 则禁止查库。
+     */
+    fun mayRedirect(context: ArtifactDownloadContext): Boolean {
+        redirectServices.forEach {
+            try {
+                if (it.mayRedirect(context)) {
+                    return true
+                }
+            } catch (ignore: Exception) {
+                logger.error("Check mayRedirect by ${it.javaClass.simpleName} failed", ignore)
+            }
+        }
+        return false
+    }
+
+    /**
+     * 是否需要重定向（不执行）。命中时记录 service 下标，供 [redirect] 直接执行，避免重复判断。
+     */
+    fun shouldRedirect(context: ArtifactDownloadContext): Boolean {
+        redirectServices.forEachIndexed { index, service ->
+            try {
+                if (service.shouldRedirect(context)) {
+                    context.putAttribute(ATTR_REDIRECT_SERVICE_INDEX, index)
+                    return true
+                }
+            } catch (ignore: Exception) {
+                logger.error("Check redirect by ${service.javaClass.simpleName} failed", ignore)
+            }
+        }
+        return false
+    }
+
+    /**
+     * 重定向下载请求（Generic 路径逻辑与原实现一致）。
+     * remapper 若已 [shouldRedirect] 命中，跳过重复判断直接执行。
      */
     fun redirect(context: ArtifactDownloadContext): Boolean {
+        val checkedIndex = context.getAttribute<Int>(ATTR_REDIRECT_SERVICE_INDEX)
+        if (checkedIndex != null) {
+            redirectServices[checkedIndex].redirect(context)
+            return true
+        }
         redirectServices.forEach {
             try {
                 if (it.shouldRedirect(context)) {
@@ -58,5 +94,6 @@ class DownloadRedirectManager(
 
     companion object {
         private val logger = LoggerFactory.getLogger(DownloadRedirectManager::class.java)
+        private const val ATTR_REDIRECT_SERVICE_INDEX = "redirect.service.index"
     }
 }

--- a/src/backend/common/common-artifact/artifact-service/src/main/kotlin/com/tencent/bkrepo/common/artifact/repository/redirect/DownloadRedirectManager.kt
+++ b/src/backend/common/common-artifact/artifact-service/src/main/kotlin/com/tencent/bkrepo/common/artifact/repository/redirect/DownloadRedirectManager.kt
@@ -71,13 +71,21 @@ class DownloadRedirectManager(
 
     /**
      * 重定向下载请求（Generic 路径逻辑与原实现一致）。
-     * remapper 若已 [shouldRedirect] 命中，跳过重复判断直接执行。
+     * remapper 若已 [shouldRedirect] 命中，跳过重复判断直接执行；失败则降级回 onDownload。
      */
     fun redirect(context: ArtifactDownloadContext): Boolean {
-        val checkedIndex = context.getAttribute<Int>(ATTR_REDIRECT_SERVICE_INDEX)
+        val checkedIndex = context.getAndRemoveAttribute<Int>(ATTR_REDIRECT_SERVICE_INDEX)
         if (checkedIndex != null) {
-            redirectServices[checkedIndex].redirect(context)
-            return true
+            return try {
+                redirectServices[checkedIndex].redirect(context)
+                true
+            } catch (ignore: Exception) {
+                logger.error(
+                    "Redirect by ${redirectServices[checkedIndex].javaClass.simpleName} failed",
+                    ignore,
+                )
+                false
+            }
         }
         redirectServices.forEach {
             try {

--- a/src/backend/common/common-artifact/artifact-service/src/main/kotlin/com/tencent/bkrepo/common/artifact/repository/redirect/DownloadRedirectService.kt
+++ b/src/backend/common/common-artifact/artifact-service/src/main/kotlin/com/tencent/bkrepo/common/artifact/repository/redirect/DownloadRedirectService.kt
@@ -33,6 +33,12 @@ import com.tencent.bkrepo.common.storage.innercos.http.HttpMethod
 interface DownloadRedirectService {
 
     /**
+     * 配置层面是否可能重定向（禁止访问 node / DB）。
+     * URI≠存储路径的仓必须先调此方法：为 false 时禁止做路径解析，直接降级。
+     */
+    fun mayRedirect(context: ArtifactDownloadContext): Boolean = false
+
+    /**
      * 支持重定向的请求方法，默认只支持GET请求
      */
     fun supportedMethods(): Set<HttpMethod> {

--- a/src/backend/common/common-artifact/artifact-service/src/main/kotlin/com/tencent/bkrepo/common/artifact/repository/remote/RemoteRepository.kt
+++ b/src/backend/common/common-artifact/artifact-service/src/main/kotlin/com/tencent/bkrepo/common/artifact/repository/remote/RemoteRepository.kt
@@ -39,6 +39,7 @@ import com.tencent.bkrepo.common.artifact.api.ArtifactFile
 import com.tencent.bkrepo.common.artifact.api.ArtifactInfo
 import com.tencent.bkrepo.common.artifact.pojo.configuration.remote.RemoteConfiguration
 import com.tencent.bkrepo.common.artifact.repository.context.ArtifactContext
+import com.tencent.bkrepo.common.artifact.repository.context.ArtifactContextHolder
 import com.tencent.bkrepo.common.artifact.repository.context.ArtifactDownloadContext
 import com.tencent.bkrepo.common.artifact.repository.context.ArtifactQueryContext
 import com.tencent.bkrepo.common.artifact.repository.context.ArtifactSearchContext
@@ -91,6 +92,31 @@ abstract class RemoteRepository : AbstractArtifactRepository() {
 
     @Autowired
     lateinit var metadataService: MetadataService
+
+    /**
+     * 与 Generic 一致：直接交由 [com.tencent.bkrepo.common.artifact.repository.redirect.DownloadRedirectManager.redirect]。
+     * 未缓存（node 不存在）时 Cos 侧不重定向；URI≠存储路径的子类先 mayRedirect 再 mapping。
+     */
+    override fun onDownloadRedirect(context: ArtifactDownloadContext): Boolean {
+        return redirectManager.redirect(context)
+    }
+
+    /**
+     * remapper 在完成路径 mapping 后调用：shouldRedirect → beforeRedirect → redirect。
+     */
+    protected fun redirectAfterPrepare(context: ArtifactDownloadContext): Boolean {
+        if (!redirectManager.shouldRedirect(context)) {
+            return false
+        }
+        val node = ArtifactContextHolder.getNodeDetail(context.artifactInfo) ?: return false
+        beforeRedirect(context, node)
+        return redirectManager.redirect(context)
+    }
+
+    /**
+     * 确认会重定向后、真正 302 前（协议头等）。
+     */
+    protected open fun beforeRedirect(context: ArtifactDownloadContext, node: NodeDetail) = Unit
 
     override fun onDownload(context: ArtifactDownloadContext): ArtifactResource? {
         return getCacheArtifactResource(context) ?: run {

--- a/src/backend/core/composer/biz-composer/src/main/kotlin/com/tencent/bkrepo/composer/artifact/repository/ComposerLocalRepository.kt
+++ b/src/backend/core/composer/biz-composer/src/main/kotlin/com/tencent/bkrepo/composer/artifact/repository/ComposerLocalRepository.kt
@@ -218,6 +218,20 @@ class ComposerLocalRepository(private val stageService: StageService) : LocalRep
         }
     }
 
+    override fun onDownloadRedirect(context: ArtifactDownloadContext): Boolean {
+        if (!redirectManager.mayRedirect(context)) {
+            return false
+        }
+        with(context) {
+            artifactInfo.setArtifactMappingUri(artifactInfo.getArtifactFullPath().removePrefix("/$DIRECT_DISTS"))
+            return redirectAfterPrepare(context)
+        }
+    }
+
+    override fun beforeRedirect(context: ArtifactDownloadContext, node: NodeDetail) {
+        packageVersion(node)?.let { downloadIntercept(context, it) }
+    }
+
     override fun onDownload(context: ArtifactDownloadContext): ArtifactResource? {
         with(context) {
             artifactInfo.setArtifactMappingUri(artifactInfo.getArtifactFullPath().removePrefix("/$DIRECT_DISTS"))

--- a/src/backend/core/conan/biz-conan/src/main/kotlin/com/tencent/bkrepo/conan/artifact/repository/ConanLocalRepository.kt
+++ b/src/backend/core/conan/biz-conan/src/main/kotlin/com/tencent/bkrepo/conan/artifact/repository/ConanLocalRepository.kt
@@ -154,6 +154,21 @@ class ConanLocalRepository : LocalRepository() {
         conanMetadataService.storeMetadata(request)
     }
 
+    override fun onDownloadRedirect(context: ArtifactDownloadContext): Boolean {
+        if (!redirectManager.mayRedirect(context)) {
+            return false
+        }
+        with(context.artifactInfo as ConanArtifactInfo) {
+            setArtifactMappingUri(generateFullPath(this))
+            return redirectAfterPrepare(context)
+        }
+    }
+
+    override fun beforeRedirect(context: ArtifactDownloadContext, node: NodeDetail) {
+        buildDownloadResponse()
+        packageVersion(context, node)?.let { downloadIntercept(context, it) }
+    }
+
     override fun onDownload(context: ArtifactDownloadContext): ArtifactResource? {
         with(context.artifactInfo as ConanArtifactInfo) {
             val fullPath = generateFullPath(this)

--- a/src/backend/core/generic/biz-generic/src/main/kotlin/com/tencent/bkrepo/generic/artifact/GenericRemoteRepository.kt
+++ b/src/backend/core/generic/biz-generic/src/main/kotlin/com/tencent/bkrepo/generic/artifact/GenericRemoteRepository.kt
@@ -82,10 +82,6 @@ import org.springframework.stereotype.Component
 class GenericRemoteRepository(
     private val genericProperties: GenericProperties,
 ) : RemoteRepository() {
-    override fun onDownloadRedirect(context: ArtifactDownloadContext): Boolean {
-        return redirectManager.redirect(context)
-    }
-
     override fun onDownload(context: ArtifactDownloadContext): ArtifactResource? {
         return getCacheArtifactResource(context) ?: run {
             val remoteConfiguration = context.getRemoteConfiguration()

--- a/src/backend/core/maven/biz-maven/src/main/kotlin/com/tencent/bkrepo/maven/artifact/repository/MavenLocalRepository.kt
+++ b/src/backend/core/maven/biz-maven/src/main/kotlin/com/tencent/bkrepo/maven/artifact/repository/MavenLocalRepository.kt
@@ -458,6 +458,28 @@ class MavenLocalRepository(
 
 
     /**
+     * 未配置 redirect 时禁止 getNodeInfoForDownload；可能 302 时再解析路径并拦截。
+     */
+    override fun onDownloadRedirect(context: ArtifactDownloadContext): Boolean {
+        if (!redirectManager.mayRedirect(context)) {
+            return false
+        }
+        return try {
+            getNodeInfoForDownload(context) ?: return false
+            redirectAfterPrepare(context)
+        } catch (ignore: MavenArtifactNotFoundException) {
+            false
+        }
+    }
+
+    override fun beforeRedirect(context: ArtifactDownloadContext, node: NodeDetail) {
+        node.metadata?.get(HashType.SHA1.ext)?.let {
+            context.response.addHeader(X_CHECKSUM_SHA1, it.toString())
+        }
+        packageVersion(node)?.let { downloadIntercept(context, it) }
+    }
+
+    /**
      * checksum 文件不存在时，系统生成
      */
     override fun onDownload(context: ArtifactDownloadContext): ArtifactResource? {

--- a/src/backend/core/oci/biz-oci/src/main/kotlin/com/tencent/bkrepo/oci/artifact/repository/OciRegistryLocalRepository.kt
+++ b/src/backend/core/oci/biz-oci/src/main/kotlin/com/tencent/bkrepo/oci/artifact/repository/OciRegistryLocalRepository.kt
@@ -48,6 +48,7 @@ import com.tencent.bkrepo.common.artifact.repository.context.ArtifactQueryContex
 import com.tencent.bkrepo.common.artifact.repository.context.ArtifactRemoveContext
 import com.tencent.bkrepo.common.artifact.repository.context.ArtifactUploadContext
 import com.tencent.bkrepo.common.artifact.repository.local.LocalRepository
+import com.tencent.bkrepo.common.artifact.repository.redirect.CosRedirectService
 import com.tencent.bkrepo.common.artifact.resolve.response.ArtifactChannel
 import com.tencent.bkrepo.common.artifact.resolve.response.ArtifactResource
 import com.tencent.bkrepo.common.artifact.stream.ArtifactInputStream
@@ -404,8 +405,32 @@ class OciRegistryLocalRepository(
     }
 
     /**
-     * 在原有逻辑上增加响应头
+     * 未配置 redirect 时禁止路径解析；可能 302 时再 mapping 并拦截。
      */
+    override fun onDownloadRedirect(context: ArtifactDownloadContext): Boolean {
+        val artifactInfo = context.artifactInfo as? OciArtifactInfo
+            ?: return super.onDownloadRedirect(context)
+        if (!redirectManager.mayRedirect(context)) {
+            return false
+        }
+        val fullPath = ociOperationService.getNodeFullPath(artifactInfo) ?: return false
+        getNodeDetail(artifactInfo, fullPath) ?: return false
+        return redirectAfterPrepare(context)
+    }
+
+    override fun beforeRedirect(context: ArtifactDownloadContext, node: NodeDetail) {
+        val artifactInfo = context.artifactInfo
+        val contentType = if (artifactInfo is OciManifestArtifactInfo) {
+            extractMediaTypeFromMetadata(node.metadata, OCI_IMAGE_MANIFEST_MEDIA_TYPE)
+        } else {
+            MediaTypes.APPLICATION_OCTET_STREAM
+        }
+        val digest = OciDigest.fromSha256(node.sha256.orEmpty())
+        OciResponseUtils.buildRedirectResponse(digest, context.response, contentType)
+        context.putAttribute(CosRedirectService.ATTR_RESPONSE_CONTENT_TYPE, contentType)
+        packageVersion(context, node)?.let { downloadIntercept(context, it) }
+    }
+
     override fun onDownload(context: ArtifactDownloadContext): ArtifactResource? {
         logger.info(
             "Will start to download oci artifact ${context.artifactInfo.getArtifactFullPath()}" +

--- a/src/backend/core/oci/biz-oci/src/main/kotlin/com/tencent/bkrepo/oci/artifact/repository/OciRegistryRemoteRepository.kt
+++ b/src/backend/core/oci/biz-oci/src/main/kotlin/com/tencent/bkrepo/oci/artifact/repository/OciRegistryRemoteRepository.kt
@@ -52,9 +52,11 @@ import com.tencent.bkrepo.common.artifact.api.ArtifactInfo
 import com.tencent.bkrepo.common.artifact.exception.NodeNotFoundException
 import com.tencent.bkrepo.common.artifact.pojo.configuration.remote.RemoteConfiguration
 import com.tencent.bkrepo.common.artifact.repository.context.ArtifactContext
+import com.tencent.bkrepo.common.artifact.repository.context.ArtifactContextHolder
 import com.tencent.bkrepo.common.artifact.repository.context.ArtifactDownloadContext
 import com.tencent.bkrepo.common.artifact.repository.context.ArtifactQueryContext
 import com.tencent.bkrepo.common.artifact.repository.context.ArtifactUploadContext
+import com.tencent.bkrepo.common.artifact.repository.redirect.CosRedirectService
 import com.tencent.bkrepo.common.artifact.repository.remote.RemoteRepository
 import com.tencent.bkrepo.common.artifact.resolve.response.ArtifactChannel
 import com.tencent.bkrepo.common.artifact.resolve.response.ArtifactResource
@@ -133,6 +135,31 @@ class OciRegistryRemoteRepository(
                 doRequest(context) as ArtifactResource?
             }
         }
+    }
+
+    /**
+     * manifest 每次拉远端，禁止缓存 302；blob 缓存命中时 mapping 后重定向。
+     */
+    override fun onDownloadRedirect(context: ArtifactDownloadContext): Boolean {
+        if (context.artifactInfo is OciManifestArtifactInfo) {
+            return false
+        }
+        val artifactInfo = context.artifactInfo as? OciArtifactInfo
+            ?: return super.onDownloadRedirect(context)
+        if (!redirectManager.mayRedirect(context)) {
+            return false
+        }
+        val fullPath = ociOperationService.getNodeFullPath(artifactInfo) ?: return false
+        artifactInfo.setArtifactMappingUri(fullPath)
+        ArtifactContextHolder.getNodeDetail(artifactInfo) ?: return false
+        return redirectAfterPrepare(context)
+    }
+
+    override fun beforeRedirect(context: ArtifactDownloadContext, node: NodeDetail) {
+        val contentType = MediaTypes.APPLICATION_OCTET_STREAM
+        val digest = OciDigest.fromSha256(node.sha256.orEmpty())
+        OciResponseUtils.buildRedirectResponse(digest, context.response, contentType)
+        context.putAttribute(CosRedirectService.ATTR_RESPONSE_CONTENT_TYPE, contentType)
     }
 
     /**

--- a/src/backend/core/oci/biz-oci/src/main/kotlin/com/tencent/bkrepo/oci/util/OciResponseUtils.kt
+++ b/src/backend/core/oci/biz-oci/src/main/kotlin/com/tencent/bkrepo/oci/util/OciResponseUtils.kt
@@ -127,6 +127,20 @@ object OciResponseUtils {
         )
     }
 
+    /**
+     * COS 302 前写入 Docker/OCI 协议头（不设置 200，由 sendRedirect 决定状态码）。
+     */
+    fun buildRedirectResponse(
+        digest: OciDigest,
+        response: HttpServletResponse,
+        contentType: String = MediaTypes.APPLICATION_OCTET_STREAM
+    ) {
+        response.addHeader(DOCKER_HEADER_API_VERSION, DOCKER_API_VERSION)
+        response.addHeader(DOCKER_CONTENT_DIGEST, digest.toString())
+        response.addHeader(HttpHeaders.ETAG, digest.toString())
+        response.addHeader(CONTENT_TYPE, contentType)
+    }
+
     fun buildDeleteResponse(response: HttpServletResponse) {
         deleteResponse(response)
     }

--- a/src/backend/core/skill/biz-skill/src/main/kotlin/com/tencent/bkrepo/skill/artifact/repository/SkillLocalRepository.kt
+++ b/src/backend/core/skill/biz-skill/src/main/kotlin/com/tencent/bkrepo/skill/artifact/repository/SkillLocalRepository.kt
@@ -138,6 +138,17 @@ class SkillLocalRepository(
         }
     }
 
+    /**
+     * zip 内单文件下载不能 COS 302（fullPath 指向整包 zip）。
+     */
+    override fun onDownloadRedirect(context: ArtifactDownloadContext): Boolean {
+        return when (context.artifactInfo) {
+            is ClawHubFileDownloadInfo -> false
+            is ClawHubArchiveDownloadInfo -> super.onDownloadRedirect(context)
+            else -> false
+        }
+    }
+
     override fun onDownload(context: ArtifactDownloadContext): ArtifactResource? {
         return when (context.artifactInfo) {
             is ClawHubArchiveDownloadInfo -> super.onDownload(context)


### PR DESCRIPTION
## Summary
- 在 `LocalRepository` 和 `RemoteRepository` 基类中覆盖 `onDownloadRedirect`，使其行为与 `GenericLocalRepository`/`GenericRemoteRepository` 一致
- Maven、NPM、PyPI、Docker、Helm 等所有依赖源仓库的本地仓和远程代理仓自动获得 COS 预签名 URL 重定向能力
- `CosRedirectService` 中已有的安全检查（node 存在性、非压缩/归档/block-node/link-node、InnerCosCredentials 等）确保不会在不适用的场景误触发

## Test plan
- [ ] Maven 本地仓下载已缓存制品返回 302 重定向至 COS
- [ ] NPM 远程代理仓缓存命中后下载可重定向，未缓存时仍走远程拉取
- [ ] 全局 `storage.redirect.enabled=false` 时重定向不生效
- [ ] `downloadRedirect` 仓库级配置对各依赖源类型生效

Fixes #4411