### PR TITLE
fix: 增加 InvalidFormatException 处理避免 Jackson 反序列化异常误映射为 500 #4435

### DIFF
--- a/src/backend/common/common-service/service-servlet/src/main/kotlin/com/tencent/bkrepo/common/service/exception/GlobalExceptionHandler.kt
+++ b/src/backend/common/common-service/service-servlet/src/main/kotlin/com/tencent/bkrepo/common/service/exception/GlobalExceptionHandler.kt
@@ -53,6 +53,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.web.HttpMediaTypeNotAcceptableException
 import org.springframework.web.HttpMediaTypeNotSupportedException
 import org.springframework.web.HttpRequestMethodNotSupportedException
+import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.MissingRequestHeaderException
 import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.bind.annotation.ExceptionHandler
@@ -179,6 +180,17 @@ class GlobalExceptionHandler : AbstractExceptionHandler() {
             status = HttpStatus.NOT_FOUND,
             messageCode = CommonMessageCode.REQUEST_URL_NOT_FOUND,
             params = arrayOf(exception.requestURL)
+        )
+        return response(errorCodeException)
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleException(exception: MethodArgumentNotValidException): Response<Void> {
+        val message = exception.fieldError?.defaultMessage ?: StringPool.EMPTY
+        val errorCodeException = ErrorCodeException(
+            status = HttpStatus.BAD_REQUEST,
+            messageCode = CommonMessageCode.PARAMETER_VALIDATION_FAILED,
+            params = arrayOf(message)
         )
         return response(errorCodeException)
     }

--- a/src/backend/common/common-service/service-servlet/src/main/kotlin/com/tencent/bkrepo/common/service/exception/GlobalExceptionHandler.kt
+++ b/src/backend/common/common-service/service-servlet/src/main/kotlin/com/tencent/bkrepo/common/service/exception/GlobalExceptionHandler.kt
@@ -31,6 +31,7 @@
 
 package com.tencent.bkrepo.common.service.exception
 
+import com.fasterxml.jackson.databind.exc.InvalidFormatException
 import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
 import com.tencent.bkrepo.common.api.constant.ANONYMOUS_USER
 import com.tencent.bkrepo.common.api.constant.HttpStatus
@@ -201,6 +202,12 @@ class GlobalExceptionHandler : AbstractExceptionHandler() {
         val userId = request?.getAttribute(USER_KEY) ?: ANONYMOUS_USER
         logger.warn("User[$userId] async request[${request?.requestURI}] not usable: ${exception.message}")
         return null
+    }
+
+    @ExceptionHandler(InvalidFormatException::class)
+    fun handleException(exception: InvalidFormatException): Response<Void> {
+        val errorCodeException = ErrorCodeException(CommonMessageCode.REQUEST_CONTENT_INVALID)
+        return response(errorCodeException)
     }
 
     @ExceptionHandler(Exception::class)


### PR DESCRIPTION
Fixes #4435

## Summary
- 在 `GlobalExceptionHandler` 增加 `InvalidFormatException` 的直接 handler，将 Jackson 枚举反序列化异常映射为 `REQUEST_CONTENT_INVALID`（HTTP 400）
- 在 `GlobalExceptionHandler` 增加 `MethodArgumentNotValidException` handler，将 Spring Validation 参数校验失败映射为 `PARAMETER_VALIDATION_FAILED`（HTTP 400）
- 两种异常之前均落入通用 `Exception` 兜底，返回 HTTP 500 + SYSTEM_ERROR + ERROR 日志

## Test plan
- [ ] 发送非法枚举值（如 `type: "PREVIEWs"`）到 `/generic/temporary/token/create`，验证返回 HTTP 400 而非 500
- [ ] 发送非法参数（如 `sort=lastModifiedDate,desc` 到布尔字段），验证返回 HTTP 400 而非 500
- [ ] 确认正常合法请求不受影响