### PR TITLE
fix: 避免 devops 非 2xx 响应反序列化失败导致 ERROR 日志 #4445

### DIFF
--- a/src/backend/auth/biz-auth/src/main/kotlin/com/tencent/bkrepo/auth/pojo/ApiResponse.kt
+++ b/src/backend/auth/biz-auth/src/main/kotlin/com/tencent/bkrepo/auth/pojo/ApiResponse.kt
@@ -34,4 +34,6 @@ package com.tencent.bkrepo.auth.pojo
 data class ApiResponse(
     val code: Int,
     val content: String
-)
+) {
+    val success: Boolean get() = code in 200..299
+}

--- a/src/backend/auth/biz-auth/src/main/kotlin/com/tencent/bkrepo/auth/service/bkdevops/CIAuthService.kt
+++ b/src/backend/auth/biz-auth/src/main/kotlin/com/tencent/bkrepo/auth/service/bkdevops/CIAuthService.kt
@@ -242,6 +242,10 @@ class CIAuthService @Autowired constructor(
             }
 
             val apiResponse = HttpUtils.doRequest(okHttpClient, request, HTTP_RETRY_COUNT, allowHttpStatusSet)
+            if (!apiResponse.success) {
+                logger.warn("$logPrefix url is $url, response code: ${apiResponse.code}")
+                return null
+            }
             logger.debug("$logPrefix, requestUrl: [$url], result: [${apiResponse.content}]")
 
             objectMapper.readValue<T>(apiResponse.content)


### PR DESCRIPTION
Fixes #4445

## Summary
- 在 `CIAuthService.executeAuthRequest` 中，反序列化 devops 响应体前先检查 HTTP 状态码是否为 2xx；非成功响应不再尝试反序列化为业务对象，直接返回 `null`，日志级别 WARN
- 在 `ApiResponse` 新增 `success` 计算属性（`code in 200..299`），供调用方判断响应是否成功
- 此前 devops 返回 4xx（`allowHttpStatusSet` 包含 400/403/404）时，错误响应体因缺少 `data` 字段导致 `jackson-module-kotlin` 抛 `MissingKotlinParameterException`，被 `catch (Exception)` 以 ERROR 级别记录

## Test plan
- [ ] devops 返回 4xx 时不再产生 ERROR 日志，仅 WARN 日志
- [ ] devops 正常 2xx 响应不受影响，`BkciAuthListResponse`/`BkciAuthCheckResponse` 等反序列化正常
- [ ] `getMemberGroupsInProject`、`isProjectMember` 等调用方降级返回空结果