### PR TITLE
fix: Maven 下载可渲染文件时补充响应头 #4457

### DIFF
--- a/src/backend/core/maven/biz-maven/src/main/kotlin/com/tencent/bkrepo/maven/artifact/repository/MavenLocalRepository.kt
+++ b/src/backend/core/maven/biz-maven/src/main/kotlin/com/tencent/bkrepo/maven/artifact/repository/MavenLocalRepository.kt
@@ -78,6 +78,7 @@ import com.tencent.bkrepo.maven.pojo.MavenRepoConf
 import com.tencent.bkrepo.maven.pojo.response.MavenArtifactResponse
 import com.tencent.bkrepo.maven.service.MavenMetadataService
 import com.tencent.bkrepo.maven.service.MavenService
+import com.tencent.bkrepo.maven.util.MavenActiveContentHeaders.applyIfActiveContent
 import com.tencent.bkrepo.maven.util.MavenConfiguration.toMavenRepoConf
 import com.tencent.bkrepo.maven.util.MavenConfiguration.versionBehaviorConflict
 import com.tencent.bkrepo.maven.util.MavenGAVCUtils.mavenGAVC
@@ -456,6 +457,11 @@ class MavenLocalRepository(
         }
     }
 
+
+    override fun onDownloadBefore(context: ArtifactDownloadContext) {
+        super.onDownloadBefore(context)
+        applyIfActiveContent(context.artifactInfo.getResponseName())
+    }
 
     /**
      * checksum 文件不存在时，系统生成

--- a/src/backend/core/maven/biz-maven/src/main/kotlin/com/tencent/bkrepo/maven/artifact/repository/MavenRemoteRepository.kt
+++ b/src/backend/core/maven/biz-maven/src/main/kotlin/com/tencent/bkrepo/maven/artifact/repository/MavenRemoteRepository.kt
@@ -57,6 +57,7 @@ import com.tencent.bkrepo.maven.pojo.MavenArtifactVersionData
 import com.tencent.bkrepo.maven.pojo.MavenGAVC
 import com.tencent.bkrepo.maven.service.MavenMetadataService
 import com.tencent.bkrepo.maven.service.MavenService
+import com.tencent.bkrepo.maven.util.MavenActiveContentHeaders.applyIfActiveContent
 import com.tencent.bkrepo.maven.util.MavenGAVCUtils.mavenGAVC
 import com.tencent.bkrepo.maven.util.MavenGAVCUtils.toMavenGAVC
 import com.tencent.bkrepo.maven.util.MavenStringUtils.checksumType
@@ -88,6 +89,11 @@ class MavenRemoteRepository(
     private val mavenService: MavenService,
 ) : RemoteRepository() {
 
+
+    override fun onDownloadBefore(context: ArtifactDownloadContext) {
+        super.onDownloadBefore(context)
+        applyIfActiveContent(context.artifactInfo.getResponseName())
+    }
 
     /**
      * 针对索引文件`maven-metadata.xml` 每次都尝试从远程拉取最新的索引文件，

--- a/src/backend/core/maven/biz-maven/src/main/kotlin/com/tencent/bkrepo/maven/util/MavenActiveContentHeaders.kt
+++ b/src/backend/core/maven/biz-maven/src/main/kotlin/com/tencent/bkrepo/maven/util/MavenActiveContentHeaders.kt
@@ -1,0 +1,33 @@
+package com.tencent.bkrepo.maven.util
+
+import com.tencent.bkrepo.common.artifact.path.PathUtils
+import com.tencent.bkrepo.common.service.util.HttpContextHolder
+
+/**
+ * 对 Maven 仓内可在浏览器渲染的内容补充响应头，保留静态页面展示并限制脚本执行。
+ */
+object MavenActiveContentHeaders {
+    private val ACTIVE_EXTENSIONS = setOf("html", "htm", "xhtml", "svg", "js", "mjs")
+
+    /**
+     * 允许静态样式/图片，限制 script/object 执行。
+     */
+    private const val CONTENT_SECURITY_POLICY =
+        "default-src 'none'; style-src 'unsafe-inline' 'self'; " +
+            "img-src 'self' data: https: http:; font-src 'self' data:; " +
+            "script-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'"
+
+    private const val HEADER_X_CONTENT_TYPE_OPTIONS = "X-Content-Type-Options"
+    private const val HEADER_CONTENT_SECURITY_POLICY = "Content-Security-Policy"
+    private const val NOSNIFF = "nosniff"
+
+    fun applyIfActiveContent(artifactName: String) {
+        val extension = PathUtils.resolveExtension(artifactName).lowercase()
+        if (extension !in ACTIVE_EXTENSIONS) {
+            return
+        }
+        val response = HttpContextHolder.getResponseOrNull() ?: return
+        response.setHeader(HEADER_X_CONTENT_TYPE_OPTIONS, NOSNIFF)
+        response.setHeader(HEADER_CONTENT_SECURITY_POLICY, CONTENT_SECURITY_POLICY)
+    }
+}

--- a/src/backend/core/maven/biz-maven/src/test/kotlin/com/tencent/bkrepo/maven/util/MavenActiveContentHeadersTest.kt
+++ b/src/backend/core/maven/biz-maven/src/test/kotlin/com/tencent/bkrepo/maven/util/MavenActiveContentHeadersTest.kt
@@ -1,0 +1,42 @@
+package com.tencent.bkrepo.maven.util
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.web.context.request.ServletRequestAttributes
+
+internal class MavenActiveContentHeadersTest {
+
+    @AfterEach
+    fun tearDown() {
+        RequestContextHolder.resetRequestAttributes()
+    }
+
+    @Test
+    fun `should set headers for html`() {
+        val response = bindResponse()
+        MavenActiveContentHeaders.applyIfActiveContent("demo-1.0.0.html")
+        assertEquals("nosniff", response.getHeader("X-Content-Type-Options"))
+        assertEquals(true, response.getHeader("Content-Security-Policy")?.contains("script-src 'none'"))
+    }
+
+    @Test
+    fun `should skip jar`() {
+        val response = bindResponse()
+        MavenActiveContentHeaders.applyIfActiveContent("demo-1.0.0.jar")
+        assertNull(response.getHeader("X-Content-Type-Options"))
+        assertNull(response.getHeader("Content-Security-Policy"))
+    }
+
+    private fun bindResponse(): MockHttpServletResponse {
+        val response = MockHttpServletResponse()
+        RequestContextHolder.setRequestAttributes(
+            ServletRequestAttributes(MockHttpServletRequest(), response)
+        )
+        return response
+    }
+}


### PR DESCRIPTION
## Summary
- Maven 下载 html/htm/xhtml/svg/js/mjs 时补充 `X-Content-Type-Options: nosniff` 与 CSP，保留静态页面展示并限制脚本执行
- 仅改 Maven 本地/远程下载前回调，不影响其它仓库类型与 jar/pom 常规拉取

## Test plan
- [x] `:core:maven:biz-maven:test --tests MavenActiveContentHeadersTest` 通过
- [ ] 浏览器访问 Maven 仓 `.html` 文件，响应含 `nosniff` 与约定 CSP，页面仍可静态展示
- [ ] jar/pom 拉取无回归

Fixes #4457